### PR TITLE
Enhance scene atmosphere and camera distance

### DIFF
--- a/r3f/src/App.jsx
+++ b/r3f/src/App.jsx
@@ -171,7 +171,7 @@ const App = () => {
         <Canvas
           shadows
           dpr={[1, 2]}
-          camera={{ position: [0, 2.8, 7.2], fov: 45 }}
+          camera={{ position: [0, 4.2, 11.5], fov: 45 }}
           gl={{
             antialias: true,
             toneMapping: THREE.ACESFilmicToneMapping,

--- a/r3f/src/threeComponents/SceneEnhancements.jsx
+++ b/r3f/src/threeComponents/SceneEnhancements.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
-import { Color, Fog } from 'three';
+import { AdditiveBlending, Color, DoubleSide, Fog } from 'three';
 import { useThree } from '@react-three/fiber';
-import { ContactShadows, Environment, Sparkles, Stars } from '@react-three/drei';
+import { ContactShadows, Environment, Float, Sparkles, Stars } from '@react-three/drei';
 
 const SceneEnhancements = () => {
   const { scene } = useThree();
@@ -40,20 +40,88 @@ const SceneEnhancements = () => {
         opacity={0.75}
       />
       <group position={[0, -0.05, 0]}>
-        <mesh rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
-          <circleGeometry args={[12, 64]} />
-          <meshStandardMaterial
-            color="#091224"
-            roughness={0.55}
-            metalness={0.4}
-            emissive="#0f264d"
-            emissiveIntensity={0.35}
-          />
-        </mesh>
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.02, 0]} receiveShadow>
           <planeGeometry args={[60, 60]} />
           <meshStandardMaterial color="#03040a" roughness={0.9} metalness={0.05} />
         </mesh>
+        <group position={[0, 0.12, 0]}>
+          <mesh rotation={[-Math.PI / 2, 0, 0]}>
+            <circleGeometry args={[6.2, 64]} />
+            <meshBasicMaterial
+              color="#0c1c36"
+              transparent
+              opacity={0.18}
+              depthWrite={false}
+              blending={AdditiveBlending}
+              toneMapped={false}
+            />
+          </mesh>
+          <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.25, 0]}>
+            <circleGeometry args={[5.5, 64]} />
+            <meshBasicMaterial
+              color="#13345a"
+              transparent
+              opacity={0.12}
+              depthWrite={false}
+              blending={AdditiveBlending}
+              toneMapped={false}
+            />
+          </mesh>
+          <mesh position={[0, 0.45, 0]}>
+            <cylinderGeometry args={[5.5, 6.5, 1.1, 48, 1, true]} />
+            <meshBasicMaterial
+              color="#13345a"
+              transparent
+              opacity={0.2}
+              depthWrite={false}
+              blending={AdditiveBlending}
+              side={DoubleSide}
+              toneMapped={false}
+            />
+          </mesh>
+        </group>
+      </group>
+      <group position={[0, 0.08, 0]}>
+        {[[-2.6, 0, 2.4], [2.6, 0, 2.4], [-2.6, 0, -2.4], [2.6, 0, -2.4]].map((position, index) => (
+          <mesh key={`plate-${index}`} position={position} castShadow receiveShadow>
+            <boxGeometry args={[1.6, 0.12, 2.8]} />
+            <meshStandardMaterial
+              color="#091427"
+              emissive="#1c6cff"
+              emissiveIntensity={0.75}
+              metalness={0.35}
+              roughness={0.4}
+            />
+          </mesh>
+        ))}
+      </group>
+      <group position={[0, 1.8, 0]}>
+        <Float speed={1.4} rotationIntensity={0.35} floatIntensity={0.6}>
+          <mesh position={[-2.1, 0.2, 0]} castShadow>
+            <icosahedronGeometry args={[0.3, 1]} />
+            <meshStandardMaterial
+              color="#67f7ff"
+              emissive="#67f7ff"
+              emissiveIntensity={2.4}
+              metalness={0.1}
+              roughness={0.25}
+              toneMapped={false}
+            />
+          </mesh>
+        </Float>
+        <Float speed={1.1} rotationIntensity={0.25} floatIntensity={0.5}>
+          <mesh position={[2.3, -0.1, -1.4]} castShadow>
+            <octahedronGeometry args={[0.24, 0]} />
+            <meshStandardMaterial
+              color="#ff7cdb"
+              emissive="#ff7cdb"
+              emissiveIntensity={2}
+              metalness={0.05}
+              roughness={0.3}
+              toneMapped={false}
+            />
+          </mesh>
+        </Float>
       </group>
       <group position={[0, 0.2, 4.5]} rotation={[0, Math.PI / 2, 0]}>
         <mesh castShadow>

--- a/r3f/src/threeComponents/SimpleCameraController.jsx
+++ b/r3f/src/threeComponents/SimpleCameraController.jsx
@@ -8,8 +8,8 @@ const CameraController = ({enableZoom = true}) => {
 
   useEffect(() => {
     const controls = new OrbitControls(camera, gl.domElement);
-    controls.minDistance = 5;
-    controls.maxDistance = 20;
+    controls.minDistance = 6.5;
+    controls.maxDistance = 28;
     controls.enableZoom = enableZoom;
     controls.enabled = controlsEnabled; // Use the state to enable/disable
     controls.enablePan = false;
@@ -31,13 +31,13 @@ const CameraController = ({enableZoom = true}) => {
     };
     if(isMobile())
     {
-      setCameraPosition(5.308,8.143,16.736);
+      setCameraPosition(6.25, 10.6, 19.8);
       console.log("IOS");
 
     }
     else
     {
-      setCameraPosition(1.705,8.6,9.381);
+      setCameraPosition(2.45, 9.4, 14.35);
       console.log('computer');
 
     }


### PR DESCRIPTION
## Summary
- replace the glowing base disk with layered ground fog, illuminated plates, and floating light sculptures to add detail
- start the default camera farther out in both the canvas setup and orbit controller limits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03b0c06a4833187788b6e801a1992