### PR TITLE
Refocus about and portfolio overlays on web work

### DIFF
--- a/r3f/src/App.css
+++ b/r3f/src/App.css
@@ -1,452 +1,500 @@
-
 @import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Pacifico&display=swap');
 
-html{
- 
-}
-html, body, #root .parent-container { 
+html,
+body,
+#root,
+.parent-container {
   width: 100%;
   height: 100%;
   margin: 0;
   padding: 0;
-  
-  
-  
-  
-  
-  
 }
-#canvas-container { /* This ID should be on the container element for your <Canvas> */
+
+body {
+  font-family: "EB Garamond", serif;
+  background-color: #010b1d;
+  color: #ffffff;
+}
+
+#canvas-container {
   width: 100vw;
   height: 100vh;
-  position: fixed; /* This positions it relative to the viewport */
-  
+  position: fixed;
   top: 0;
   left: 0;
-  z-index: 1; /* Ensures it doesn't overlap UI elements like your parameter adjustment interface */
+  z-index: 1;
 }
+
 .scrollable {
-  overflow-y: auto; /* Show scrollbar when overlay is active */
+  overflow-y: auto;
   overflow-x: hidden;
   scroll-behavior: smooth;
 }
-.notScrollable
-{
+
+.notScrollable {
   overflow: hidden;
 }
-/* Ensure the parent of Canvas and DisplayedComponent has a relative positioning */
+
 .parent-container {
   position: relative;
-  
-  
 }
-/* Customizes the whole scrollbar */
+
 ::-webkit-scrollbar {
-  width: 16px; /* Width of the vertical scrollbar */
-  height: 16px; /* Height of the horizontal scrollbar */
+  width: 16px;
+  height: 16px;
 }
 
-/* Customizes the track (background) of the scrollbar */
 ::-webkit-scrollbar-track {
-  background: linear-gradient(to bottom, #333, #000000); /* Example gradient */
-  border-radius: 8px; /* Rounded corners for the track */
+  background: linear-gradient(to bottom, #333, #000000);
+  border-radius: 8px;
 }
 
-/* Customizes the handle (thumb) of the scrollbar */
 ::-webkit-scrollbar-thumb {
-  background: linear-gradient(to bottom, #0650f0, #3023ae); /* Example gradient */
-  border-radius: 8px; /* Rounded corners for the thumb */
+  background: linear-gradient(to bottom, #0650f0, #3023ae);
+  border-radius: 8px;
 }
 
-/* Style for the overlay content */
 .overlay-content {
-  position: relative; /* Use fixed to ensure it covers the entire viewport */
-  
-  
+  position: fixed;
+  inset: 0;
   width: 100vw;
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  align-items: center;
-  z-index: 1000; /* High z-index to ensure it's above everything else */
-  background-color: rgba(0, 0, 0, 0.5);
-  color: white;
-  font-size: 24px;
-  pointer-events: none; /* Start without interaction and enable when visible */
-  opacity: 0; /* Start fully transparent */
+  align-items: flex-start;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  background-color: rgba(3, 9, 23, 0.65);
+  backdrop-filter: blur(6px);
+  z-index: 1000;
+  color: #ffffff;
+  font-size: 1rem;
+  pointer-events: none;
+  opacity: 0;
+  overflow-y: auto;
   font-family: "EB Garamond", serif;
-  font-weight: 400;
 }
 
-
-.page
-{
+.page {
   position: relative;
-  width: 100%;
-  height: 100%;
-  background-color: #09192E;
-  margin: 0; 
-  padding: 0;
-  
-}
-
-.page button{
-  background-color: transparent; 
-  color: white;
-  border: none;
-}
-
-
-
-.page button h1{
-  font-family: "Pacifico", cursive;
-  
-  
-}
-
-.Format{
-  width: 100%;
-  height: 100%;
-  display:flex;
-  justify-content: center;
-  align-items: center;
-  margin: 0; 
-  padding: 0;
-  
-}
-
-.Section
-{
-  justify-content: center;
-  align-items: center;
-  padding-left: 25vw;
-  width: 100%;
-  height:100%;
-}
-.portfolioContainer{
-  
-  justify-content: center;
-  text-align:center;
-  
-  padding-left: 0vw;
-}
-
-.aboutMe{
-  padding-top: 15vh;
-}
-.Section b{
-  color:cyan;
-}
-.aboutSection{
-  display: flex;
-  padding-right: 10vw;
-  
-}
-
-.aboutSkills
-{
-  display: flex;
-  padding: 10px;
-}
-.aboutLeft{
-  width: 100%;
-  height: 100%;
-  
-}
-.aboutRight
-{
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.aboutModel
-{
-  width: 100%;
-  height: 100%;
-  padding-left:10px;
-  padding-bottom: 50vh;
-  display: flex;
-  justify-content:flex-start;
-  
-  
-  
-}
-.aboutModel img{
-  
-  width: 330px;
-  height: 400px;
-  
-}
-.aboutSkills{
-  
-  width: 100%;
-  height: 100%;
-}
-.resumeButton
-{
-  text-decoration: none;
-
-}
-.resumeButton button{
-  font-family: "EB Garamond", serif;
-  font-size: inherit;
-  background-color: rgb(7, 185, 185);
-  border-radius: 5px;
-}
-.contactSection{
+  width: min(1100px, 100%);
+  min-height: 70vh;
+  background-color: rgba(9, 25, 46, 0.92);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  margin: 0 auto;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 50px;
-  height: 100vh;
-  
-  
-  
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
-.contactBox{
+
+.page > button {
+  background-color: transparent;
+  color: #ffffff;
+  border: none;
+  align-self: flex-start;
+  cursor: pointer;
+}
+
+.page > button h1 {
+  font-family: "Pacifico", cursive;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  margin: 0;
+}
+
+.Format {
+  width: 100%;
   display: flex;
-  
-  height: 100%;
-}
-.leftContactSection{
-  display: block;
-}
-.rightContactSection{
-  display: block;
-  padding-left: 20px;
-  width: 100%;
-  
-  
-}
-.contactTitle{
   justify-content: center;
-  text-align: center;
+}
+
+.Section {
   width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
 }
-.contactTitle h4{
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.35em;
+  font-size: 0.75rem;
+  color: #7aa6ff;
+}
+
+.aboutSection {
+  display: grid;
+  grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
+  gap: clamp(1.75rem, 3vw, 3rem);
+  align-items: flex-start;
+}
+
+.aboutPrimary {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+}
+
+.aboutPrimary h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  line-height: 1.1;
+}
+
+.aboutSummary {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #d6e4ff;
+  margin: 0;
+}
+
+.aboutPrimary p {
+  margin: 0;
+  color: #c7d6f7;
+  line-height: 1.7;
+}
+
+.aboutHighlights {
+  background: rgba(12, 33, 58, 0.75);
+  border: 1px solid rgba(46, 220, 218, 0.18);
+  border-radius: 18px;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+}
+
+.aboutHighlights h2 {
+  margin: 0;
+}
+
+.aboutHighlights ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.75rem;
+  color: #d6e4ff;
+  line-height: 1.55;
+}
+
+.aboutActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.aboutActions p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #8fa9d6;
+}
+
+.resumeButton {
+  text-decoration: none;
+  align-self: flex-start;
+}
+
+.resumeButton button {
+  font-family: "EB Garamond", serif;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #2edcda, #0650f0);
+  border-radius: 999px;
+  border: none;
+  color: #ffffff;
+  padding: 0.75rem 1.75rem;
+  cursor: pointer;
+  box-shadow: 0 14px 35px rgba(6, 80, 240, 0.35);
+}
+
+.aboutSecondary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.aboutCard {
+  background: rgba(9, 25, 46, 0.85);
+  border: 1px solid rgba(46, 220, 218, 0.12);
+  border-radius: 18px;
+  padding: clamp(1rem, 2.5vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.3);
+}
+
+.aboutCard h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.aboutCard ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+  color: #c7d6f7;
+  line-height: 1.55;
+}
+
+.aboutCard p {
+  margin: 0;
+  color: #d6e4ff;
+  line-height: 1.6;
+}
+
+.aboutSkillsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.skillGroup h3 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+  color: #7aa6ff;
+}
+
+.skillGroup ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  color: #c7d6f7;
+}
+
+.aboutExperienceTitle {
+  font-weight: 600;
+  color: #2edcda;
+}
+
+.aboutPhotoCard {
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+}
+
+.aboutPhotoCard img {
+  width: 100%;
+  max-width: 260px;
+  height: auto;
+  border-radius: 18px;
+  object-fit: cover;
+  align-self: center;
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.4);
+}
+
+.aboutEducation {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.aboutEducation h2 {
+  margin: 0;
+}
+
+.aboutEducation p {
+  margin: 0;
+  color: #c7d6f7;
+}
+
+.portfolioContainer {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 3rem);
+  text-align: left;
+}
+
+.portfolioContainer h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.portfolioIntro {
+  margin: 0;
+  max-width: 720px;
+  color: #d6e4ff;
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+.portfolioGroup {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.75rem);
+}
+
+.portfolioGroupHeader h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.portfolioGroupHeader p {
+  margin: 0.35rem 0 0;
+  color: #8fa9d6;
+  line-height: 1.6;
+  max-width: 640px;
+}
+
+.contactSection {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.contact-container {
+  display: flex;
+  justify-content: center;
+}
+
+.contactBox {
+  display: flex;
+  gap: 2rem;
+}
+
+.leftContactSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 260px;
+}
+
+.rightContactSection {
+  flex: 1;
+}
+
+.contactTitle {
+  text-align: center;
+}
+
+.contactTitle h4 {
   color: #0650f0;
-  
+  margin-bottom: 0.35rem;
 }
+
 .contact-container h2,
 .contact-container h3 {
-  color: #fff; /* Replace with actual color codes */
+  color: #ffffff;
+  margin: 0;
 }
-.contact-form{
-  display: block;
-  height: 100%;
-  width: 100%;
-  
-  
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .contact-form input,
 .contact-form button,
 .contact-form textarea {
   display: block;
-  /* Styles for the form fields */
-  margin-bottom: 15px;
-  color: white;
-  padding: 10px;
+  color: #ffffff;
+  padding: 0.75rem;
   border: none;
-  font-size: 20px;
+  font-size: 1rem;
   border-bottom: 2px solid;
   border-radius: 5px;
   width: 100%;
-  padding-top: 30px;
   background-color: transparent;
   border-image: linear-gradient(to right, #4000ff, #011fff) 1;
   resize: none;
-  
-  
 }
+
 .contact-form textarea::placeholder,
-.contact-form input::placeholder{
+.contact-form input::placeholder {
   font-family: "EB Garamond", serif;
   color: #0650f0;
 }
-.contact-form input:focus, .contact-form textarea:focus {
-  outline: 2px solid #0650f0; 
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: 2px solid #0650f0;
 }
-
-
 
 .contact-form button {
-  
-  /* Styles for the submit button */
-  background: #3023ae; 
+  background: #3023ae;
   font-family: "EB Garamond", serif;
-  
-  color: white;
+  color: #ffffff;
   border: none;
-  padding: 10px 10px;
+  padding: 0.6rem 1rem;
   border-radius: 5px;
   cursor: pointer;
-  width: 100px;
-  
-  
+  width: 120px;
+  align-self: center;
 }
-.contact-form div{
+
+.contact-form div {
   display: flex;
   justify-content: center;
-  align-items: center;
 }
-.leftContactSection div{
-  padding-top: 10px;
+
+.leftContactSection div {
   display: flex;
-
-  
-}
-
-.leftContactMail{
-  
   align-items: center;
-  font-size: 20px;
+  gap: 0.75rem;
+}
+
+.leftContactMail,
+.leftContactGithub {
+  font-size: 1rem;
   color: #4000ff;
- 
 }
-.leftContactMail a {
-  text-decoration: none; 
-  color: inherit; 
-}
-.leftContactGithub{
-  align-items: center;
-  font-size: 20px;
-  color: #4000ff;
-  
-}
+
+.leftContactMail a,
 .leftContactGithub a {
-  text-decoration: none; 
-  color: inherit; 
+  text-decoration: none;
+  color: inherit;
 }
 
-.leftContactImages{
+.leftContactImages {
   width: 35px;
   height: 35px;
-  padding-right: 10px;
-  
-  
 }
 
-
-/* iphone*/
-@media only screen 
-  and (min-device-width: 393px) 
-  and (max-device-width: 852px) { 
-    .Section
-    {
-      justify-content: center;
-      align-items: center;
-      
-      
-      width: 100%;
-      height:100%;
-    }
-
-    .Format{
-      width: 100%;
-      height: 100%;
-      
-      display:flex;
-      justify-content: center;
-      align-items: center;
-      margin: 0; 
-      padding: 0;
-      
-    }
-    .aboutSection{
-      display: block;
-      padding: 0;
-      
-    }
-    .contactBox
-    {
-      display: block;
-    }
-    .rightContactSection
-    {
-      padding: 0;
-    }
-    .aboutMe
-    {
-      padding: 10px;
-    }
-    .aboutModel img{
-  
-      width: 280px;
-      height: 330px;
-      
-    }
-  
-}
-
-/* ipad */
-@media only screen 
-  and (min-device-width: 830px) 
-  and (max-device-width: 1024px) {
-    .aboutSection{
-      display: flex;
-      padding: 20px;
-      
-    }
-    .contactBox{
-      display: flex;
+@media (max-width: 1024px) {
+  .aboutSection {
+    grid-template-columns: 1fr;
   }
-  .aboutModel
-  {
-    
-    height: 100vh;
+
+  .aboutSecondary {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
-  
 }
 
-/* computer */
-@media (max-width: 900px)
-{
-  .Section
-    {
-      justify-content: center;
-      align-items: center;
-      
-      
-      width: 100%;
-      height:100%;
-    }
+@media (max-width: 900px) {
+  .page {
+    padding: clamp(1.25rem, 6vw, 2.25rem);
+  }
 
-    .Format{
-      width: 100%;
-      height: 100%;
-      
-      display:flex;
-      justify-content: center;
-      align-items: center;
-      margin: 0; 
-      padding: 0;
-      
-    }
-    .aboutSection{
-      display: block;
-      padding: 0;
-      
-    }
-    .contactBox
-    {
-      display: block;
-    }
-    .rightContactSection
-    {
-      padding: 0;
-    }
-    .aboutMe
-    {
-      padding: 10px;
-    }
-    .aboutModel img{
-  
-      width: 280px;
-      height: 330px;
-      
-    }
+  .portfolioGroupHeader p {
+    max-width: 100%;
+  }
+
+  .contactBox {
+    flex-direction: column;
+  }
+
+  .rightContactSection {
+    padding-left: 0;
+  }
 }
+
+@media (max-width: 600px) {
+  .overlay-content {
+    padding: 1.25rem;
+  }
+
+  .page {
+    border-radius: 18px;
+  }
+
+  .aboutHighlights ul,
+  .aboutCard ul {
+    padding-left: 1rem;
+  }
+
+  .leftContactSection {
+    max-width: none;
+  }
+}
+

--- a/r3f/src/Card.css
+++ b/r3f/src/Card.css
@@ -1,228 +1,171 @@
 .portfolioSection {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-  padding: 10px;
-  justify-content: center;
-  align-items: flex-start; /* Align items at the start of the cross axis */
-  margin: 0 auto;
-  width: 50%; /* Adjust the width as needed */
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.25rem, 2.5vw, 2rem);
 }
-  
-.card {
-  flex: 0 0 calc(33.333% - 40px); /* Do not grow or shrink, just set the basis */
-  margin-bottom: 20px; /* Consistent space between rows */
-  height: 410px;
-  background-color: #060c12;
-  border-radius: 10px;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-  overflow: hidden;
-  /* No need to set width or margin auto since flex-basis handles the size and gap + justify-content centers the items */
-}
-  
-  
-  .card-inner {
-    position: relative;
-    width: 100%; /* Fill the .card container */
-    height: 100%; /* Fill the .card container */
-    text-align: center;
-    transition: transform 0.6s;
-    transform-style: preserve-3d;
-  }
-  
-  .card-front,
-  .card-back {
-    position: absolute;
-    width: 100%; /* Fill the .card-inner container */
-    height: 100%; /* Fill the .card-inner container */
-    backface-visibility: hidden;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between; /* Distribute space between elements */
-    align-items: center; /* Center align the content */
-    
-  }
-  
-  .card-front {
-    background-color: #060c12;
-  }
-  
-  .card-back {
-    background-color: #060c12;
-    transform: rotateY(180deg);
-  }
-  
-  .is-flipped {
-    transform: rotateY(180deg);
-  }
-  
-  .card-image {
-    filter: invert(33%) sepia(95%) saturate(748%) hue-rotate(183deg) brightness(90%) contrast(89%);
 
-    width: 100px;
-    height: 100px; /* Adjust the height of the image */
-    object-fit: cover; /* Ensures image covers the area */
-    border-top-left-radius: 10px;
-    border-top-right-radius: 10px;
-  }
-.card-description-box{
-  
+.card {
+  perspective: 1600px;
   height: 100%;
 }
-.card-description{
-  font-size: 20px;
 
-}
-.description-back{
-  font-size: 17px;
-  color: white;
-
-}
-
-.card button{
-  background: #26427f;
-  font-family: "EB Garamond", serif;
-  border-radius: 5px;
-  font-size: 15px;
-}
-.linkLogo{
-  filter: invert(33%) sepia(95%) saturate(748%) hue-rotate(183deg) brightness(90%) contrast(89%);
-  width: 40px;
-  height: 40px;
-  
-}
-
-.logoContainer{
-  display: flex;
+.card-inner {
+  position: relative;
   width: 100%;
-  justify-content: flex-end;
+  min-height: 360px;
+  height: 100%;
+  text-align: left;
+  transition: transform 0.6s ease;
+  transform-style: preserve-3d;
+}
+
+.card-front,
+.card-back {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(12, 30, 55, 0.95), rgba(5, 15, 28, 0.92));
+  border: 1px solid rgba(122, 166, 255, 0.25);
+  border-radius: 18px;
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 1rem;
+  backface-visibility: hidden;
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+}
+
+.card-back {
+  transform: rotateY(180deg);
+}
+
+.card-inner.is-flipped {
+  transform: rotateY(180deg);
+}
+
+.card-image {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  filter: invert(33%) sepia(95%) saturate(748%) hue-rotate(183deg) brightness(90%) contrast(89%);
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #ffffff;
+}
+
+.card-description {
+  font-size: 1rem;
+  color: #d6e4ff;
+  line-height: 1.55;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card-description p {
+  margin: 0;
+}
+
+.card-description ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.card-tags {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.card-tags li {
+  background: rgba(122, 166, 255, 0.16);
+  color: #9fc0ff;
+  border: 1px solid rgba(122, 166, 255, 0.35);
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.card-btn {
+  align-self: flex-start;
+  background: rgba(46, 220, 218, 0.15);
+  color: #2edcda;
+  border: 1px solid rgba(46, 220, 218, 0.4);
+  font-family: "EB Garamond", serif;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  padding: 0.5rem 1.25rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.card-btn:hover {
+  transform: translateY(-2px);
+  background: rgba(46, 220, 218, 0.3);
+}
+
+.logoContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.linkLogo {
+  width: 42px;
+  height: 42px;
+  filter: invert(33%) sepia(95%) saturate(748%) hue-rotate(183deg) brightness(90%) contrast(89%);
+  transition: transform 0.2s ease;
+}
+
+.linkText {
+  color: #9fc0ff;
+  font-size: 0.95rem;
+  text-decoration: underline;
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+}
+
+.card-description-box {
+  flex: 1;
 }
 
 .custom-tooltip {
-  visibility: hidden; 
-  opacity: 0; 
   position: absolute;
-  z-index: 1000; 
-  pointer-events: none; 
-  background-color:#26427f; 
-  color: white; 
-  padding: 10px; 
-  border-radius: 4px; 
-  font-size: 12px; 
-  white-space: nowrap; 
-  font-family:'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif
+  z-index: 1000;
+  pointer-events: none;
+  background-color: rgba(38, 66, 127, 0.95);
+  color: white;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  font-family: "EB Garamond", serif;
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.35);
+  visibility: hidden;
+  opacity: 0;
 }
 
-
-
-
-/* iphone*/
-@media only screen 
-  and (min-device-width: 393px) 
-  and (max-device-width: 852px) { 
-    .portfolioSection {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      padding: 10px;
-      justify-content: center;
-      align-items: flex-start; /* Align items at the start of the cross axis */
-      margin: 0 auto;
-      width: 80%; /* Adjust the width as needed */
-    }
-    .card {
-      flex: 0 0 calc(90% - 40px); /* Do not grow or shrink, just set the basis */
-      margin-bottom: 10px; /* Consistent space between rows */
-      height: 400px;
-      background-color: #060c12;
-      border-radius: 10px;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-      overflow: hidden;
-    }
-    .description-back{
-      font-size: 16px;
-      color: white;
-    
-    }
-  
-}
-
-/* ipad */
-@media only screen 
-  and (min-device-width: 830px) 
-  and (max-device-width: 1024px) {
-    .portfolioSection {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      padding: 10px;
-      justify-content: center;
-      align-items: flex-start; /* Align items at the start of the cross axis */
-      margin: 0 auto;
-      width: 60%; /* Adjust the width as needed */
-    }
-    .card {
-      flex: 0 0 calc(50% - 40px); /* Do not grow or shrink, just set the basis */
-      margin-bottom: 10px; /* Consistent space between rows */
-      height: 400px;
-      background-color: #060c12;
-      border-radius: 10px;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-      overflow: hidden;
-    }
-  
-}
-
-/* computer */
-@media (max-width: 1700px)
-  {
-    .portfolioSection {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      padding: 10px;
-      justify-content: center;
-      align-items: flex-start; /* Align items at the start of the cross axis */
-      margin: 0 auto;
-      width: 60%; /* Adjust the width as needed */
-    }
-    .card {
-      flex: 0 0 calc(50% - 40px); /* Do not grow or shrink, just set the basis */
-      margin-bottom: 10px; /* Consistent space between rows */
-      height: 400px;
-      background-color: #060c12;
-      border-radius: 10px;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-      overflow: hidden;
-    }
+@media (max-width: 1070px) {
+  .portfolioSection {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
+}
 
-  @media (max-width: 1070px)
-  {
-    .portfolioSection {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      padding: 10px;
-      justify-content: center;
-      align-items: flex-start; /* Align items at the start of the cross axis */
-      margin: 0 auto;
-      width: 80%; /* Adjust the width as needed */
-    }
-    .card {
-      flex: 0 0 calc(90% - 40px); /* Do not grow or shrink, just set the basis */
-      margin-bottom: 10px; /* Consistent space between rows */
-      height: 400px;
-      background-color: #060c12;
-      border-radius: 10px;
-      box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-      overflow: hidden;
-    }
-    .description-back{
-      font-size: 16px;
-      color: white;
-    
-    }
+@media (max-width: 700px) {
+  .card-inner {
+    min-height: 340px;
   }
+}
 
-  

--- a/r3f/src/components/about.jsx
+++ b/r3f/src/components/about.jsx
@@ -1,168 +1,196 @@
-import React, { useRef, useEffect } from 'react';
+/* eslint-disable react/prop-types */
+import { useRef, useEffect } from 'react';
 import { gsap } from 'gsap';
 import { useDisplay } from '../threeComponents/DisplayContextManager';
-import ScrollTrigger from 'gsap/src/ScrollTrigger';
 
-gsap.registerPlugin(ScrollTrigger);
+const highlights = [
+  'Architect web platforms that connect Next.js frontends with Express and FastAPI services for live trading data.',
+  'Design secure brokerage workflows using Charles Schwab OAuth, encrypted token storage, and auditable API layers.',
+  'Build voice-enabled automation loops that stream SpeechRecognition → LLM → TTS interactions across WebSockets.',
+  'Instrument analytics and backtesting modules so traders can make confident, data-backed decisions.',
+];
+
+const skillGroups = [
+  {
+    title: 'Frontend Engineering',
+    items: ['React & Next.js', 'TypeScript / JavaScript', 'GSAP & animation systems', 'Three.js & R3F scenes'],
+  },
+  {
+    title: 'Services & Data',
+    items: ['Node.js & Express APIs', 'FastAPI & Python workflows', 'MongoDB & Mongoose', 'REST APIs & WebSockets'],
+  },
+  {
+    title: 'Intelligence & Automation',
+    items: ['AI/ML integrations', 'pandas & NumPy analytics', 'Speech recognition & TTS', 'Trading API orchestration'],
+  },
+  {
+    title: 'Collaboration',
+    items: ['Git & CI-ready repos', 'Product discovery & user journeys', 'Technical documentation', 'Rapid iteration with feedback'],
+  },
+];
+
+const experiencePoints = [
+  'Scoped and shipped an AI-assisted trading platform linking Next.js, Express, and FastAPI services.',
+  'Wrapped Alpaca & Schwab endpoints in reusable providers that expose unified portfolio data to the UI.',
+  'Launched a React authentication context that manages refresh tokens, protected routes, and session lifecycle.',
+  'Partnered with stakeholders to prioritize releases, track impact metrics, and document architectural decisions.',
+];
+
+const workflowValues = [
+  'Start with user flows, then layer in components and services that support the journey.',
+  'Prototype quickly, validate with instrumentation, and harden solutions with automated checks.',
+  'Share knowledge across the team through pairing, documentation, and thoughtful code reviews.',
+];
 
 const About = ({ hideOverlay }) => {
   const buttonRef = useRef(null);
   const aboutSectionRef = useRef(null);
-  const { isVisible } = useDisplay(); // using context to check if the component is visible
-  const isMobile = /Android|webOS|iPhone|iPad|iPad Pro|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-  const isIpad = window.matchMedia("(min-device-width: 830px) and (max-device-width: 1024px)").matches;
-  
+  const { isVisible } = useDisplay();
+
   useEffect(() => {
-    // Example animation tied to the visibility of the section
-    if (isVisible) {
-
-      
-      
-        if (isMobile || isIpad) 
-        {
-          // Simpler animation for mobile devices
-          gsap.to('.page', { autoAlpha: isVisible ? 1 : 0, duration: 0.5 });
-        } else 
-        {
-          
-            const timeline = gsap.timeline({defaults: {duration: 1, ease: 'power2.out'}});
-            timeline
-              .fromTo('.page', {autoAlpha: 0, scale: 0.5}, {autoAlpha: 1, scale: 1})
-              .fromTo('.page', {rotationY: -90}, {rotationY: 0, ease: 'back.out(1.7)'}, '<')
-              .fromTo('.page *', {autoAlpha: 0, y: 20}, {autoAlpha: 1, y: 0, stagger: 0.1}, '-=0.5');
-
-          
-        }
+    if (!isVisible || !aboutSectionRef.current) {
+      return;
     }
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
+
+    if (prefersReducedMotion || isTouchDevice) {
+      gsap.fromTo(
+        aboutSectionRef.current,
+        { autoAlpha: 0, y: 40 },
+        { autoAlpha: 1, y: 0, duration: 0.8, ease: 'power1.out' }
+      );
+      return;
+    }
+
+    const tl = gsap.timeline({ defaults: { duration: 0.8, ease: 'power2.out' } });
+    tl.fromTo('.page', { autoAlpha: 0, scale: 0.9 }, { autoAlpha: 1, scale: 1 })
+      .fromTo(
+        aboutSectionRef.current,
+        { autoAlpha: 0, y: 60 },
+        { autoAlpha: 1, y: 0 }
+      )
+      .fromTo(
+        aboutSectionRef.current.querySelectorAll('.aboutCard, .aboutPrimary'),
+        { autoAlpha: 0, y: 30 },
+        { autoAlpha: 1, y: 0, stagger: 0.12 },
+        '-=0.4'
+      );
+
+    return () => tl.kill();
   }, [isVisible]);
-  
 
-  if (isMobile || isIpad) 
-  {
-    useEffect(() => {
-      if (isVisible) {
-        gsap.fromTo(aboutSectionRef.current, { autoAlpha: 0, y: 50 }, { autoAlpha: 1, y: 0, duration: 1 });
-      }
-    }, [isVisible]);
-
-  }
-  
   useEffect(() => {
-    // Button hover animations
-    const scaleUp = () => gsap.to(buttonRef.current, { scale: 1.2, duration: 0.3 });
-    const scaleDown = () => gsap.to(buttonRef.current, { scale: 1, duration: 0.3 });
+    if (!buttonRef.current) return;
 
-    buttonRef.current.addEventListener('mouseenter', scaleUp);
-    buttonRef.current.addEventListener('mouseleave', scaleDown);
+    const button = buttonRef.current;
+    const scaleUp = () => gsap.to(button, { scale: 1.12, duration: 0.25 });
+    const scaleDown = () => gsap.to(button, { scale: 1, duration: 0.25 });
 
-    // Cleanup function for button event listeners
+    button.addEventListener('mouseenter', scaleUp);
+    button.addEventListener('mouseleave', scaleDown);
+
     return () => {
-      // Safely remove event listeners only if buttonRef.current is not null
-      if (buttonRef.current) {
-        buttonRef.current.removeEventListener('mouseenter', scaleUp);
-        buttonRef.current.removeEventListener('mouseleave', scaleDown);
-      }
+      button.removeEventListener('mouseenter', scaleUp);
+      button.removeEventListener('mouseleave', scaleDown);
     };
   }, []);
 
-  if (isMobile || isIpad) 
-  {
-    useEffect(() => {
-      // Only trigger the GSAP timeline when the section is visible
-      if (isVisible) {
-        const tl = gsap.timeline();
-        tl.fromTo(
-          aboutSectionRef.current, 
-          { autoAlpha: 0, y: 50 }, 
-          { autoAlpha: 1, y: 0, duration: 1, ease: "power1.out" }
-        );
-      }
-    }, [isVisible]); // Depend on isVisible to re-trigger the animation*/
-
-  }
-  const scaleUp = (e) => gsap.to(e.currentTarget, { scale: 1.2, duration: 0.3 });
- const scaleDown = (e) => gsap.to(e.currentTarget, { scale: 1, duration: 0.3 });
+  const handleScaleUp = (event) => gsap.to(event.currentTarget, { scale: 1.12, duration: 0.25 });
+  const handleScaleDown = (event) => gsap.to(event.currentTarget, { scale: 1, duration: 0.25 });
 
   return (
-    <>
-    
-      <div className="page">
-        <button ref={buttonRef} onClick={hideOverlay}>
-          <h1>Back</h1>
-        </button>
-        <div className="Format">
-          <div className="Section aboutSection" ref={aboutSectionRef}>
-            <div className="aboutMe">
-
-            
-            <h1>About Me</h1>
-              <p>Hello, my name is <b>William</b> I am a <b>Gameplay Programmer</b> and a <b>Front-End Developer</b>. My interests in both stem from my immense satisfaction 
-                from translating thoughts into playable realities.
-              </p>
-              <p>
-              I love to solve problems and make the journey fun while doing so. I believe in consistent learning and sharing knowledge while maintaining 
-              a sense of joy in the process. 
-              Collaborating on ambitious projects to bring functionality to life is a pursuit I thoroughly enjoy. It is my aspiration to contribute my skills 
-                and passion to create clean, well organized systems while
-                collaborating with a like-minded team, to produce innovative games and websites that players can appreciate.
-              </p>
-
-              <p>
-                I just released a <b>plugin for Unreal Engine</b>. The plugin is called <b>Visual Save</b> and its main purpose is to encode 
-                Save Game data into images, allowing for players to load, share and save their progress via images. The plugin presented a lot of challenges and enlightening moments that I had to solve and learn. Go check it out in my portfolio section.
-              </p>
-            <a href="https://docs.google.com/document/d/12GtkKixHYPvFlJCWfXx_4etS_pKIu5v70eESW6R86J4/export?format=pdf" download title="Download Resume" className="resumeButton">
-              <button onMouseEnter={scaleUp} onMouseLeave={scaleDown}>
-                Download Resume
-              </button>
-            
-          </a>
-            
-          
-          <p>Here are some of my skills</p>
-                <div className="aboutSkills">
-                  <div className="WebDevelopment">
-                  <ul>
-                      <li style={{ listStyleType: 'none' }}><u><b>Front-End Development</b></u></li>
-                      <li>React - ☆☆☆☆</li>
-                      <li>React-Three-Fiber - ☆☆</li>
-                      <li>GSAP - ☆☆☆☆</li>
-                      <li>THREE.js - ☆☆☆☆</li>
-                      <li>Javascript - ☆☆☆☆</li>
-                      <li>Typescript - ☆☆</li>
-                      <li>HTML - ☆☆☆☆</li>
-                      <li>CSS - ☆☆☆☆</li>
-                    </ul>
-                  </div>
-                </div>
-                  <div className="GameProgramming">
-                    <ul>
-                      
-                    <li style={{ listStyleType: 'none' }}><u><b>Game Development</b></u></li>
-                      <li> Knowledge of Unreal Engine 5 - ☆☆☆☆</li>
-                      <li> C++ - ☆☆☆☆☆</li>
-                      <li> C - ☆☆☆☆☆</li>
-                      <li> C# - ☆☆☆</li>
-                      <li>Computer Graphics - ☆☆</li>
-                      <li>Game physics and mathematics - ☆☆☆</li>
-                      <li> AI programming within Unreal Engine - ☆☆☆</li>
-                    </ul>
-                  </div>
-
-            
+    <div className="page">
+      <button ref={buttonRef} onClick={hideOverlay}>
+        <h1>Back</h1>
+      </button>
+      <div className="Format">
+        <section className="Section aboutSection" ref={aboutSectionRef}>
+          <div className="aboutPrimary">
+            <span className="eyebrow">About</span>
+            <h1>Web experiences powered by real-time data</h1>
+            <p className="aboutSummary">
+              Full-stack junior developer experienced in building AI-driven trading platforms that blend
+              real-time market data, automated strategies, and voice-enabled assistants across modern web
+              and Python services.
+            </p>
+            <p>
+              I specialize in translating complex workflows into approachable web products. Whether it’s
+              connecting streaming market data, automating brokerage tasks, or layering in AI assistants,
+              I focus on reliable systems and clean UX that feel effortless to use.
+            </p>
+            <div className="aboutHighlights">
+              <h2>Where I create value</h2>
+              <ul>
+                {highlights.map((highlight) => (
+                  <li key={highlight}>{highlight}</li>
+                ))}
+              </ul>
             </div>
-            <div className='aboutModel'>
-              <img src="/static/Billy.png" alt="Billy" />
+            <div className="aboutActions">
+              <a
+                href="https://docs.google.com/document/d/12GtkKixHYPvFlJCWfXx_4etS_pKIu5v70eESW6R86J4/export?format=pdf"
+                download
+                title="Download Resume"
+                className="resumeButton"
+              >
+                <button onMouseEnter={handleScaleUp} onMouseLeave={handleScaleDown}>
+                  Download Resume
+                </button>
+              </a>
+              <p>Open to collaborating on ambitious, human-centered web platforms.</p>
+            </div>
           </div>
-          </div>
-            
-          
-        </div>
+          <aside className="aboutSecondary">
+            <div className="aboutCard">
+              <h2>Core Skills</h2>
+              <div className="aboutSkillsGrid">
+                {skillGroups.map(({ title, items }) => (
+                  <div className="skillGroup" key={title}>
+                    <h3>{title}</h3>
+                    <ul>
+                      {items.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className="aboutCard">
+              <h2>Experience Snapshot</h2>
+              <p className="aboutExperienceTitle">Stock Bot Web Application — Developer</p>
+              <ul>
+                {experiencePoints.map((point) => (
+                  <li key={point}>{point}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="aboutCard">
+              <h2>How I work</h2>
+              <ul>
+                {workflowValues.map((value) => (
+                  <li key={value}>{value}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="aboutCard aboutPhotoCard">
+              <img src="/static/Billy.png" alt="William Wapniarek" />
+              <div className="aboutEducation">
+                <h2>Education</h2>
+                <p>
+                  <strong>University of Advancing Technology</strong>
+                </p>
+                <p>B.S. Computer Science — 2024</p>
+              </div>
+            </div>
+          </aside>
+        </section>
       </div>
-      
-      
-    </>
+    </div>
   );
 };
 
 export default About;
+

--- a/r3f/src/components/portfolio.jsx
+++ b/r3f/src/components/portfolio.jsx
@@ -1,65 +1,198 @@
-import React, { useRef, useEffect } from 'react';
+/* eslint-disable react/prop-types */
+import { useRef, useEffect } from 'react';
 import gsap from 'gsap';
 import ScrollTrigger from 'gsap/ScrollTrigger';
 import { useDisplay } from '../threeComponents/DisplayContextManager';
 import Card from '../threeComponents/PortfolioCard';
 
-gsap.registerPlugin(ScrollTrigger); // Register ScrollTrigger plugin outside of the component
+gsap.registerPlugin(ScrollTrigger);
 
-const Portfolio = ({ hideOverlay, canShowAnimationComputer }) => {
+const projectGroups = [
+  {
+    heading: 'Featured Build',
+    subheading: 'Production web apps that orchestrate services, automation, and responsive UI.',
+    projects: [
+      {
+        image: '/static/Website.png',
+        title: 'Stock Bot Web Application',
+        description: (
+          <>
+            <p>
+              Real-time trading cockpit that connects a Next.js interface with Node.js/Express
+              services and a FastAPI trading engine.
+            </p>
+          </>
+        ),
+        tags: ['Next.js', 'Express', 'FastAPI', 'WebSockets', 'OAuth2'],
+        readMoreContent: (
+          <ul>
+            <li>
+              Streamed live market data, orders, and alerts into the dashboard through resilient
+              WebSocket channels.
+            </li>
+            <li>
+              Implemented Charles Schwab OAuth with AES-256-GCM token vaulting and MongoDB
+              persistence for brokerage integrations.
+            </li>
+            <li>
+              Embedded a Jarvis-style voice assistant loop (SpeechRecognition → LLM → TTS) for
+              hands-free portfolio walkthroughs.
+            </li>
+            <li>
+              Delivered configurable backtesting analytics with ATR-based risk management and
+              performance reporting for traders.
+            </li>
+          </ul>
+        ),
+        links: [
+          {
+            href: 'https://github.com/BilliamsFluster',
+            label: 'Repository',
+            icon: '/static/Github.png',
+            tooltip: 'Explore related GitHub work',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    heading: 'Supporting Web Projects',
+    subheading: 'Experiments that explore new interaction patterns and data-driven UX.',
+    projects: [
+      {
+        image: '/static/Website.png',
+        title: 'Immersive Portfolio Platform',
+        description: (
+          <>
+            <p>
+              Story-driven recruiting experience blending React Three Fiber scenes with overlay
+              narratives and GSAP timelines.
+            </p>
+          </>
+        ),
+        tags: ['React', 'React Three Fiber', 'GSAP', 'Vite'],
+        readMoreContent: (
+          <ul>
+            <li>
+              Synced 3D camera choreography with overlay components to highlight each chapter of the
+              story without losing immersion.
+            </li>
+            <li>
+              Implemented a DisplayContext system that locks scene controls while overlays are
+              active, keeping the focus on content.
+            </li>
+            <li>
+              Crafted micro-interactions with GSAP to provide hover feedback, entry animations, and
+              smooth transitions between sections.
+            </li>
+          </ul>
+        ),
+        links: [
+          {
+            href: 'https://bwap.netlify.app/',
+            label: 'Live site',
+            icon: '/static/Website.png',
+            tooltip: 'Open the live portfolio',
+          },
+          {
+            href: 'https://github.com/BilliamsFluster',
+            label: 'Code',
+            icon: '/static/Github.png',
+            tooltip: 'View source control work',
+          },
+        ],
+      },
+      {
+        image: '/static/Website.png',
+        title: 'Movie Discovery Dashboard',
+        description: (
+          <>
+            <p>
+              Responsive catalog for browsing films via a third-party API with rich search and
+              filtering.
+            </p>
+          </>
+        ),
+        tags: ['React', 'REST APIs', 'Responsive UI'],
+        readMoreContent: (
+          <ul>
+            <li>
+              Integrated remote movie data with reusable React hooks for fetching, error handling,
+              and loading states.
+            </li>
+            <li>
+              Designed card-based layouts that adapt to mobile, tablet, and desktop breakpoints to
+              keep discovery fast.
+            </li>
+            <li>
+              Applied modular component patterns to extend filters and featured views without
+              rewriting state management.
+            </li>
+          </ul>
+        ),
+        links: [
+          {
+            href: 'https://github.com/BilliamsFluster/react_film_site',
+            label: 'Repository',
+            icon: '/static/Github.png',
+            tooltip: 'Inspect the React codebase',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const Portfolio = ({ hideOverlay }) => {
   const buttonRef = useRef(null);
   const portfolioSectionRef = useRef(null);
   const { isVisible } = useDisplay();
-  let tl = useRef(gsap.timeline({ paused: true })).current; // Store the timeline in a ref
-  
-  useEffect(() => {
-    gsap.registerPlugin(ScrollTrigger);
-    const sectionEl = portfolioSectionRef.current;
+  const timelineRef = useRef();
 
-    if (isVisible && sectionEl) {
-      // Use the tl from the ref, don't recreate it
-      tl = gsap.timeline({
+  useEffect(() => {
+    if (!isVisible || !portfolioSectionRef.current) {
+      return;
+    }
+
+    const sectionEl = portfolioSectionRef.current;
+    timelineRef.current = gsap
+      .timeline({
         scrollTrigger: {
           trigger: sectionEl,
-          start: 'top center+=100',
+          start: 'top center+=80',
           toggleActions: 'play none none none',
-          // Make sure to clean up this ScrollTrigger in the return function
         },
-      });
-
-      tl.fromTo(
+      })
+      .fromTo(
         sectionEl,
-        { autoAlpha: 0, y: 50 },
-        { autoAlpha: 1, y: 0, duration: 1, ease: 'power1.out' }
+        { autoAlpha: 0, y: 60 },
+        { autoAlpha: 1, y: 0, duration: 1, ease: 'power2.out' }
       )
       .fromTo(
         sectionEl.querySelectorAll('.card'),
-        { autoAlpha: 0, y: 30 },
+        { autoAlpha: 0, y: 40 },
         {
           autoAlpha: 1,
           y: 0,
-          stagger: 0.2, // Delay between each card animation
-          duration: 0.8,
+          stagger: 0.15,
+          duration: 0.7,
           ease: 'power1.out',
         },
-        '-=0.5' // This overlaps the timeline slightly to make the animation smoother
+        '-=0.4'
       );
-    }
 
-    // Cleanup function
     return () => {
-      if (tl) {
-        tl.kill(); // Kill the timeline if it's defined
-      }
-      ScrollTrigger.getAll().forEach(trigger => trigger.kill()); // Clear all ScrollTriggers
+      timelineRef.current?.kill();
+      ScrollTrigger.getAll().forEach((trigger) => trigger.kill());
     };
   }, [isVisible]);
 
-
   useEffect(() => {
+    if (!buttonRef.current) return;
+
     const button = buttonRef.current;
-    const scaleUp = () => gsap.to(button, { scale: 1.2, duration: 0.3 });
-    const scaleDown = () => gsap.to(button, { scale: 1, duration: 0.3 });
+    const scaleUp = () => gsap.to(button, { scale: 1.12, duration: 0.25 });
+    const scaleDown = () => gsap.to(button, { scale: 1, duration: 0.25 });
 
     button.addEventListener('mouseenter', scaleUp);
     button.addEventListener('mouseleave', scaleDown);
@@ -73,67 +206,29 @@ const Portfolio = ({ hideOverlay, canShowAnimationComputer }) => {
   return (
     <div className="page">
       <button ref={buttonRef} onClick={hideOverlay}>
-        <h1>Back  </h1>
+        <h1>Back</h1>
       </button>
       <div className="Format">
         <div className="Section portfolioContainer" ref={portfolioSectionRef}>
-          <h1><u>Portfolio</u></h1>
-          <div className="portfolioSection">
-          <Card 
-              image="/static/Website.png"
-              title="Portfolio Site"
-              description="Skills Developed: This Portfolio improved on my React, R3F(React-Three-Fiber), and javascript skills."
-              readMoreContent="Chalenges I Faced: Working with R3F is something I have never done before. This was blocking me from translating my ideas into reality. How I overcame this was to reach out for help, discord, youtube and the R3F docs really helped me 
-              become more proficent in R3F and front-end as a whole. Understanding the use of gsap and how it worked with R3F took some time as well. I wanted to make this site because I strive for creativity.
-              Making this website gave me a chance to be myself and let my creativity loose."
-              links={[{ href: 'https://bwap.netlify.app/', text: ' Link' }]}
-              linkLogo={"/static/Github.png"}
-              tooltip = {"View on Github"}
-            />
-            <Card 
-            image="/static/Website.png"
-            title="Movie Site"
-            description="Skills Developed: This website taught me how to use an API to fetch movie data and use it in React."
-            readMoreContent="Challenges I Faced: Working on implementing the API to fetch movie data was something that I have not done before. Using react with this as well presented some difficulty in the beginning
-            Giving myself some time to look over documentation and draw out a plan to provide more clarity helped out a lot. Once I did all of this implementing the API with React was a lot easier and more efficent."
-            links={[{ href: 'https://github.com/BilliamsFluster/react_film_site', text: ' Link' }]}
-            linkLogo={"/static/Github.png"}
-            tooltip = {"View on Github"}
-          />
-            <Card 
-              image="/static/Plugin.png"
-              title="Visual Save - UE5 Plugin"
-              description="Skills Developed: Steganography with UE5, Slate, system desgn."
-              readMoreContent="Challenges I Faced: This plugin was actually a school project recommended by my professor. Since no one has done this project before documentation and help was very scarce.
-              What I did to overcome this was to break down the plugin into smaller chunks like the drag drop system, and the encoding and decoding of data. I then looked for relevant examples within the engine's soruce code 
-              to utilize and understand the classes neccessary to achieve this innovative plugin."
-              links={[{ href: 'https://www.unrealengine.com/marketplace/en-US/product/visual-save-plugin', text: ' Link' }]}
-              linkLogo={"/static/Market.png"}
-              tooltip = {"View Visual Save on UE5 Marketplace"}
-            />
-            <Card 
-              image="/static/GameEngine.png"
-              title="Blu - Game Engine"
-              description="Skills Developed: Deeper understanding of low level system design and premake along with mono and C# integration. "
-              readMoreContent="Challenges I Faced: When planning out BLU planning the event system and the rendering system proved to be a challenge. These systems need to be extremely robust and efficent or else performance and quality will be comprimised.
-              How I over came these two obstacles was to break down what they were into smaller components.  I know that the event system need a way to dispatch, receive, and pass events through layers. This level of thinking 
-              helped me implement these systems into BLU."
-              links={[{ href: 'https://github.com/BilliamsFluster/Blu', text: ' Link' }]}
-              linkLogo={"/static/Github.png"}
-              tooltip={" View BLU on Github"}
-            />
-            <Card 
-              image="/static/UnrealEngine.png"
-              title="Survive The Enemies - Game"
-              description="Skills Developed: Enemy AI integration, inventory and locomotion system."
-              readMoreContent="Challenges I Faced: Implementing a different approach to the weapon system proved to be quite difficult at first. Instead of each weapon being its own actor I went with one main weapon 
-              pulling weapon data from a data table, pistol data, AR data etc. I implemented this system because it makes adding weapons in the future much more effient.
-              It simplifies the designers job when adding new features into the game."
-              links={[{ href: 'https://youtu.be/qUgCkX0peI4', text: ' Link' }]}
-              linkLogo={"/static/Youtube.png"}
-              tooltip={"View This Game on Youtube"}
-            />
-          </div>
+          <span className="eyebrow">Works</span>
+          <h1>Web Projects</h1>
+          <p className="portfolioIntro">
+            A curated look at the web experiences I build—from production trading platforms that
+            blend AI, automation, and security to supporting prototypes that explore new UI ideas.
+          </p>
+          {projectGroups.map(({ heading, subheading, projects }) => (
+            <section className="portfolioGroup" key={heading}>
+              <div className="portfolioGroupHeader">
+                <h2>{heading}</h2>
+                {subheading && <p>{subheading}</p>}
+              </div>
+              <div className="portfolioSection">
+                {projects.map((project) => (
+                  <Card key={project.title} {...project} />
+                ))}
+              </div>
+            </section>
+          ))}
         </div>
       </div>
     </div>
@@ -141,3 +236,4 @@ const Portfolio = ({ hideOverlay, canShowAnimationComputer }) => {
 };
 
 export default Portfolio;
+

--- a/r3f/src/threeComponents/PortfolioCard.jsx
+++ b/r3f/src/threeComponents/PortfolioCard.jsx
@@ -1,21 +1,24 @@
-import React, { useState, useEffect, useRef } from 'react';
+/* eslint-disable react/prop-types */
+import { useState, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { gsap } from 'gsap';
 import "../Card.css";
 
-const Card = ({ image, title, description, readMoreContent, links, linkLogo, tooltip }) => {
+const Card = ({ image, title, description, readMoreContent, links = [], tags = [] }) => {
   const [isFlipped, setIsFlipped] = useState(false);
   const [tooltipVisible, setTooltipVisible] = useState(false);
-  const [tooltipContent, setTooltipContent] = useState('Tooltip');
+  const [tooltipContent, setTooltipContent] = useState('');
   const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
   const tooltipRef = useRef(null);
 
   const showTooltip = (e, text) => {
-    const linkRect = e.target.getBoundingClientRect();
+    if (!text) return;
+
+    const linkRect = e.currentTarget.getBoundingClientRect();
     setTooltipContent(text);
     setTooltipPosition({
-      x: linkRect.left + (linkRect.width / 2) + window.scrollX,
-      y: linkRect.top + window.scrollY - linkRect.height + 30 // Adjusted to move the tooltip higher
+      x: linkRect.left + linkRect.width / 2 + window.scrollX,
+      y: linkRect.top + window.scrollY - linkRect.height + 30,
     });
     setTooltipVisible(true);
   };
@@ -25,71 +28,97 @@ const Card = ({ image, title, description, readMoreContent, links, linkLogo, too
   };
 
   useEffect(() => {
-    if (tooltipRef.current) {
-      if (tooltipVisible) {
-        gsap.to(tooltipRef.current, { duration: 0.3, autoAlpha: 1 });
-      } else {
-        gsap.to(tooltipRef.current, { duration: 0.3, autoAlpha: 0 });
-      }
-    }
+    if (!tooltipRef.current) return;
+
+    gsap.to(tooltipRef.current, {
+      duration: 0.3,
+      autoAlpha: tooltipVisible ? 1 : 0,
+    });
   }, [tooltipVisible]);
 
   const handleFlip = () => {
-    setIsFlipped(!isFlipped);
+    setIsFlipped((prev) => !prev);
   };
 
   const tooltipEl = (
-    <div 
-      ref={tooltipRef} 
-      className="custom-tooltip" 
+    <div
+      ref={tooltipRef}
+      className="custom-tooltip"
       style={{
-        position: 'absolute',
         top: `${tooltipPosition.y}px`,
         left: `${tooltipPosition.x}px`,
-        transform: 'translate(-50%, -100%)'
-      }}>
+        transform: 'translate(-50%, -100%)',
+      }}
+    >
       {tooltipContent}
     </div>
   );
-  const scaleUp = (e) => gsap.to(e.currentTarget, { scale: 1.2, duration: 0.3 });
-  const scaleDown = (e) => gsap.to(e.currentTarget, { scale: 1, duration: 0.3 });
+
+  const scaleUp = (target) => gsap.to(target, { scale: 1.12, duration: 0.25 });
+  const scaleDown = (target) => gsap.to(target, { scale: 1, duration: 0.25 });
+
+  const tooltipRoot = document.getElementById('tooltip-root');
 
   return (
     <>
       <div className="card">
         <div className={`card-inner ${isFlipped ? 'is-flipped' : ''}`}>
           <div className="card-front">
-            <img src={image} alt="Project" className="card-image" />
+            <img src={image} alt={title} className="card-image" />
             <h3 className="card-title">{title}</h3>
-            <p className="card-description description-front">{description}</p>
-            <button onClick={handleFlip} className="card-btn">Read More</button>
+            <div className="card-description description-front">{description}</div>
+            {tags.length > 0 && (
+              <ul className="card-tags">
+                {tags.map((tag) => (
+                  <li key={tag}>{tag}</li>
+                ))}
+              </ul>
+            )}
+            <button onClick={handleFlip} className="card-btn">
+              Read More
+            </button>
           </div>
           <div className="card-back">
-            <div className="logoContainer">
-              {links.map((link, index) => (
-                <a key={index} 
-                   href={link.href} 
-                   className="card-link" 
-                   target="_blank" 
-                   rel="noopener noreferrer"
-                   onMouseEnter={(e) => showTooltip(e, tooltip)}
-                   onMouseLeave={hideTooltip}>
-                  <img src={linkLogo} alt="Link Logo" className="linkLogo"
-                    onMouseEnter={scaleUp} onMouseLeave={scaleDown}
-                  />
-                </a>
-              ))}
+            {links.length > 0 && (
+              <div className="logoContainer">
+                {links.map(({ href, label, icon, tooltip }, index) => (
+                  <a
+                    key={`${label}-${index}`}
+                    href={href}
+                    className="card-link"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onMouseEnter={(e) => showTooltip(e, tooltip)}
+                    onMouseLeave={hideTooltip}
+                  >
+                    {icon ? (
+                      <img
+                        src={icon}
+                        alt={label || 'Project link'}
+                        className="linkLogo"
+                        onMouseEnter={(event) => scaleUp(event.currentTarget)}
+                        onMouseLeave={(event) => scaleDown(event.currentTarget)}
+                      />
+                    ) : (
+                      <span className="linkText">{label}</span>
+                    )}
+                  </a>
+                ))}
+              </div>
+            )}
+            <div className="card-description-box">
+              <div className="card-description description-back">{readMoreContent}</div>
             </div>
-            <div className='card-description-box'>
-              <p className="card-description description-back">{readMoreContent}</p>
-            </div>
-            <button onClick={handleFlip} className="card-btn">Read Less</button>
+            <button onClick={handleFlip} className="card-btn">
+              Read Less
+            </button>
           </div>
         </div>
       </div>
-      {tooltipVisible && ReactDOM.createPortal(tooltipEl, document.getElementById('tooltip-root'))}
+      {tooltipVisible && tooltipRoot && ReactDOM.createPortal(tooltipEl, tooltipRoot)}
     </>
   );
 };
 
 export default Card;
+


### PR DESCRIPTION
## Summary
- rewrite the About overlay with a web-focused summary, highlight panels, and updated GSAP animations for touch and desktop visitors
- replace the Portfolio overlay with data-driven project groups and refreshed copy that spotlights production web work
- restyle overlay layouts and portfolio cards so the content centers within the viewport and supports richer metadata and tooltips

## Testing
- npm run lint *(fails: existing lint violations throughout the project)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0526aac6483319cb6c0f7b9d3657a