### PR TITLE
Refocus about and portfolio content on web development

### DIFF
--- a/r3f/src/App.css
+++ b/r3f/src/App.css
@@ -75,12 +75,15 @@ body {
 
 .shad-sheet__panel {
   position: fixed;
-  top: 0;
-  bottom: 0;
-  width: min(420px, 90vw);
+  top: clamp(1.25rem, 4vh, 3rem);
+  bottom: clamp(1.25rem, 4vh, 3rem);
+  right: clamp(1.5rem, 4vw, 3.5rem);
+  width: min(640px, calc(100vw - 4rem));
+  max-height: calc(100vh - 2 * clamp(1.25rem, 4vh, 3rem));
   background: rgba(9, 25, 46, 0.92);
   backdrop-filter: blur(18px);
-  border-left: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1.25rem;
   box-shadow: -18px 0 48px rgba(15, 23, 42, 0.45);
   display: flex;
   flex-direction: column;
@@ -89,11 +92,12 @@ body {
 }
 
 .shad-sheet__panel--right {
-  right: 0;
+  right: clamp(1.5rem, 4vw, 3.5rem);
 }
 
 .shad-sheet__panel--left {
-  left: 0;
+  left: clamp(1.5rem, 4vw, 3.5rem);
+  right: auto;
 }
 
 .shad-sheet__header,
@@ -140,7 +144,7 @@ body {
 .shad-scroll-area__viewport {
   height: 100%;
   overflow-y: auto;
-  padding: 1.75rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
 }
 
 .shad-scroll-area__viewport::-webkit-scrollbar {
@@ -223,6 +227,9 @@ body {
   flex-direction: column;
   gap: 1.75rem;
   min-height: 100%;
+  width: min(720px, 100%);
+  margin: 0 auto;
+  padding-bottom: 2.5rem;
 }
 
 .section-header {
@@ -233,9 +240,10 @@ body {
 
 .section-header__meta {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 .section-eyebrow {
@@ -261,7 +269,13 @@ body {
 
 .section-grid {
   display: grid;
-  gap: 1.25rem;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.section-grid--about {
+  grid-auto-rows: 1fr;
+  align-items: stretch;
 }
 
 .section-card {
@@ -275,6 +289,12 @@ body {
   box-shadow: 0 20px 45px rgba(8, 15, 35, 0.35);
 }
 
+.section-card--primary {
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.28), rgba(15, 23, 42, 0.72));
+  border-color: rgba(59, 130, 246, 0.45);
+  box-shadow: 0 25px 55px rgba(30, 64, 175, 0.35);
+}
+
 .section-card__title {
   margin: 0;
   font-size: 1.1rem;
@@ -285,6 +305,19 @@ body {
   margin: 0;
   font-size: 0.85rem;
   color: rgba(148, 163, 184, 0.8);
+}
+
+.section-subtitle {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: -0.01em;
+}
+
+.section-subheader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
 }
 
 .skill-tag-list {
@@ -329,6 +362,15 @@ body {
   letter-spacing: 0.02em;
 }
 
+.section-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.55rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
 .about-portrait {
   display: flex;
   align-items: center;
@@ -348,7 +390,23 @@ body {
 
 .projects-grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.projects-grid--supporting {
+  gap: 1.35rem;
+}
+
+.works-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.featured-works {
+  display: grid;
+  gap: 1.35rem;
 }
 
 .project-card {
@@ -360,6 +418,14 @@ body {
   background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(17, 24, 39, 0.6));
   padding: 1.35rem;
   box-shadow: 0 22px 45px rgba(8, 15, 35, 0.35);
+}
+
+.project-card--featured {
+  padding: 1.65rem;
+  gap: 1.1rem;
+  border-color: rgba(59, 130, 246, 0.4);
+  background: linear-gradient(170deg, rgba(30, 64, 175, 0.32), rgba(15, 23, 42, 0.78));
+  box-shadow: 0 28px 55px rgba(30, 64, 175, 0.35);
 }
 
 .project-card__header {
@@ -395,6 +461,15 @@ body {
   color: rgba(226, 232, 240, 0.82);
   line-height: 1.6;
   margin: 0;
+}
+
+.project-card__list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
 }
 
 .project-card__footer {
@@ -473,5 +548,14 @@ body {
 
   .shad-sheet__panel {
     width: 100vw;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    border-radius: 0;
+  }
+
+  .shad-scroll-area__viewport {
+    padding: 1.5rem;
   }
 }

--- a/r3f/src/components/about.jsx
+++ b/r3f/src/components/about.jsx
@@ -1,24 +1,33 @@
 import React from 'react';
 import Button from './ui/button';
 
-const frontEndSkills = [
-  { label: 'React', level: '☆☆☆☆' },
-  { label: 'React Three Fiber', level: '☆☆☆' },
-  { label: 'GSAP', level: '☆☆☆☆' },
-  { label: 'Three.js', level: '☆☆☆☆' },
-  { label: 'JavaScript', level: '☆☆☆☆' },
-  { label: 'TypeScript', level: '☆☆' },
-  { label: 'HTML & CSS', level: '☆☆☆☆' },
+const focusAreas = [
+  'Real-time market dashboards',
+  'AI-assisted user journeys',
+  'Secure brokerage integrations',
+  'Automation & testing'
 ];
 
-const gameDevSkills = [
-  { label: 'Unreal Engine 5', level: '☆☆☆☆' },
-  { label: 'C++', level: '☆☆☆☆☆' },
-  { label: 'C', level: '☆☆☆☆☆' },
-  { label: 'C#', level: '☆☆☆' },
-  { label: 'Computer Graphics', level: '☆☆' },
-  { label: 'Game Math & Physics', level: '☆☆☆' },
-  { label: 'AI Programming', level: '☆☆☆' },
+const skillColumns = [
+  {
+    title: 'Front-end',
+    items: ['React & Next.js', 'TypeScript & JavaScript', 'React Three Fiber / Three.js', 'GSAP animation systems', 'Responsive design systems'],
+  },
+  {
+    title: 'Back-end',
+    items: ['Node.js & Express APIs', 'FastAPI microservices', 'MongoDB & Mongoose', 'WebSockets & streaming data', 'OAuth 2.0 flows'],
+  },
+  {
+    title: 'Data & AI',
+    items: ['Python (pandas, NumPy)', 'AI/ML assisted product features', 'Speech recognition & TTS', 'Strategy & backtesting engines', 'Git-based collaboration'],
+  },
+];
+
+const impactHighlights = [
+  'Orchestrated a multi-service trading stack that links a Next.js UI, Node/Express API, and FastAPI trading engine for live execution.',
+  'Implemented Charles Schwab OAuth with AES-256-GCM token vaulting and broker account verification inside MongoDB pipelines.',
+  'Built a Jarvis voice assistant loop that streams SpeechRecognition into LLM prompts and TTS playback for hands-free trading.',
+  'Engineered a configurable backtesting and momentum strategy framework with ATR stops, slippage modelling, and performance metrics.',
 ];
 
 const About = ({ onClose }) => {
@@ -28,70 +37,69 @@ const About = ({ onClose }) => {
         <div className="section-header__meta">
           <div>
             <p className="section-eyebrow">About</p>
-            <h2 className="section-title">Engineering playful, technical experiences</h2>
+            <h2 className="section-title">Designing intelligent web products</h2>
           </div>
           <Button variant="ghost" size="sm" onClick={onClose}>
             Back to scene
           </Button>
         </div>
         <p className="section-lead">
-          I&apos;m William, a gameplay programmer and front-end developer who loves translating ideas into interactive
-          realities. I thrive when I can mix creative storytelling with reliable systems design to craft experiences that
-          feel polished, playful, and personal.
+          Full-stack junior developer experienced in building AI-driven trading platforms that blend real-time market
+          data, automated strategies, and voice-enabled assistants across modern web and Python services.
         </p>
       </div>
 
-      <div className="section-grid">
-        <div className="section-card">
-          <h3 className="section-card__title">What I&apos;m focused on</h3>
+      <div className="section-grid section-grid--about">
+        <div className="section-card section-card--primary">
+          <h3 className="section-card__title">How I build</h3>
           <p className="project-card__body">
-            I enjoy solving complex problems with a human touch. Whether it&apos;s prototyping a new mechanic, polishing
-            interface details, or optimising a pipeline, I love creating spaces where people feel curious and in control.
-            Recent work includes <strong>Visual Save</strong>, an Unreal Engine plugin that encodes save game data into
-            images so players can store and share their progress creatively.
+            I translate complex financial workflows into approachable web applications. My focus is pairing reliable
+            engineering practices with purposeful motion and storytelling, so every screen balances clarity, trust, and
+            delight.
           </p>
           <div className="skill-tag-list">
-            <span className="skill-tag">Gameplay Programming</span>
-            <span className="skill-tag">Front-End UI</span>
-            <span className="skill-tag">Technical Art</span>
-            <span className="skill-tag">Systems Design</span>
+            {focusAreas.map((area) => (
+              <span key={area} className="skill-tag">
+                {area}
+              </span>
+            ))}
           </div>
           <Button variant="default" asChild>
             <a href="https://docs.google.com/document/d/12GtkKixHYPvFlJCWfXx_4etS_pKIu5v70eESW6R86J4/export?format=pdf" download>
-              Download resume
+              Download résumé
             </a>
           </Button>
         </div>
 
         <div className="section-card">
+          <h3 className="section-card__title">Recent impact</h3>
+          <p className="section-card__meta">Stock Bot Web Application</p>
+          <ul className="section-list">
+            {impactHighlights.map((highlight) => (
+              <li key={highlight}>{highlight}</li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="section-card">
           <h3 className="section-card__title">Skill snapshot</h3>
-          <p className="section-card__meta">A blend of web technology and game engine expertise.</p>
+          <p className="section-card__meta">Tooling I reach for when shaping web platforms.</p>
           <div className="skill-columns">
-            <ul>
-              <li>
-                <strong>Front-End</strong>
-              </li>
-              {frontEndSkills.map((skill) => (
-                <li key={skill.label}>
-                  {skill.label} – {skill.level}
+            {skillColumns.map((column) => (
+              <ul key={column.title}>
+                <li>
+                  <strong>{column.title}</strong>
                 </li>
-              ))}
-            </ul>
-            <ul>
-              <li>
-                <strong>Game Development</strong>
-              </li>
-              {gameDevSkills.map((skill) => (
-                <li key={skill.label}>
-                  {skill.label} – {skill.level}
-                </li>
-              ))}
-            </ul>
+                {column.items.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            ))}
           </div>
         </div>
 
         <div className="section-card about-portrait">
-          <img src="/static/Billy.png" alt="William portrait" />
+          <img src="/static/Billy.png" alt="Portrait of William Wapniarek" />
         </div>
       </div>
     </div>

--- a/r3f/src/components/portfolio.jsx
+++ b/r3f/src/components/portfolio.jsx
@@ -1,57 +1,54 @@
 import React from 'react';
 import Button from './ui/button';
 
-const projects = [
+const featuredWorks = [
   {
-    title: 'Immersive Portfolio',
-    tags: ['React', 'R3F', 'GSAP'],
+    title: 'Stock Bot Web Application',
     summary:
-      'A personal world built with React Three Fiber to showcase work through a playable scene and animated storytelling.',
-    challenge:
-      'Learning the R3F ecosystem pushed me to blend Three.js, GSAP timelines, and component-driven UI patterns in a cohesive way.',
-    links: [{ label: 'Visit site', href: 'https://bwap.netlify.app/', variant: 'default' }],
-  },
-  {
-    title: 'Film Explorer',
-    tags: ['React', 'REST APIs'],
-    summary:
-      'A movie discovery experience that consumes a film API, presenting curated watchlists with responsive search and filtering.',
-    challenge:
-      'Integrating a third-party API taught me how to plan data flows, normalise payloads, and build resilient loading states.',
-    links: [{ label: 'View GitHub', href: 'https://github.com/BilliamsFluster/react_film_site', variant: 'outline' }],
-  },
-  {
-    title: 'Visual Save Plugin',
-    tags: ['Unreal Engine', 'C++', 'Tools'],
-    summary:
-      'Marketplace plugin that encodes save-game data into images so players can store, share, and load progress from visual files.',
-    challenge:
-      'Reverse-engineering Unreal’s save pipeline and Slate UI required meticulous system design and a creative approach to data.',
+      'AI-assisted trading platform that combines a Next.js front-end, Node/Express orchestration layer, and a Python trading engine.',
+    highlights: [
+      'Unified real-time market data, automated strategies, and broker operations into a single portfolio dashboard.',
+      'Delivered Schwab OAuth onboarding with AES-256-GCM token storage and brokerage account verification using Mongoose hooks.',
+      'Built a Jarvis voice assistant loop that streams SpeechRecognition into LLM prompts and TTS playback for hands-free trade execution.',
+      'Shipped a backtesting toolkit with momentum strategies, ATR-based risk controls, and slippage modelling for accurate performance insights.',
+    ],
+    stack: ['Next.js', 'Express', 'FastAPI', 'MongoDB', 'WebSockets', 'LLMs', 'GSAP'],
     links: [
       {
-        label: 'Marketplace page',
-        href: 'https://www.unrealengine.com/marketplace/en-US/product/visual-save-plugin',
+        label: 'View architecture notes',
+        href: 'https://docs.google.com/document/d/12GtkKixHYPvFlJCWfXx_4etS_pKIu5v70eESW6R86J4',
         variant: 'default',
       },
     ],
   },
+];
+
+const supportingProjects = [
   {
-    title: 'BLU Game Engine',
-    tags: ['C++', 'Engine Architecture'],
-    summary:
-      'A hobby engine exploring rendering layers, event dispatching, and editor tooling with a focus on extensibility.',
-    challenge:
-      'Designing the event and rendering systems meant breaking large problems into smaller primitives that could evolve safely.',
-    links: [{ label: 'View GitHub', href: 'https://github.com/BilliamsFluster/Blu', variant: 'outline' }],
+    title: 'Immersive Portfolio',
+    description:
+      'Interactive personal site where visitors explore projects inside a playable React Three Fiber world layered with GSAP storytelling.',
+    impact:
+      'Reinforced my ability to blend creative direction, shader-driven visuals, and accessible UI states within a single codebase.',
+    stack: ['React', 'React Three Fiber', 'GSAP'],
+    links: [{ label: 'Visit site', href: 'https://bwap.netlify.app/', variant: 'default' }],
   },
   {
-    title: 'Survive The Enemies',
-    tags: ['Unreal Engine', 'Gameplay'],
-    summary:
-      'Action prototype featuring modular weapons, enemy AI, and inventory systems tuned for fast iteration in Unreal.',
-    challenge:
-      'Refactoring the weapon system into a single data-driven actor made future balancing easier for designers and teammates.',
-    links: [{ label: 'Watch demo', href: 'https://youtu.be/qUgCkX0peI4', variant: 'default' }],
+    title: 'Film Explorer',
+    description:
+      'Responsive web app that surfaces curated watchlists by orchestrating third-party film APIs with debounced search and filter states.',
+    impact: 'Showcased pragmatic data modelling, resilient error states, and reusable UI primitives for content-heavy experiences.',
+    stack: ['React', 'REST APIs', 'CSS Modules'],
+    links: [{ label: 'View GitHub', href: 'https://github.com/BilliamsFluster/react_film_site', variant: 'outline' }],
+  },
+  {
+    title: 'Strategy Sandbox',
+    description:
+      'Configurable analysis suite that lets traders prototype momentum ideas, tweak ATR-based stops, and visualise returns before deploying.',
+    impact:
+      'Extended my backtesting engine with reusable hooks, clear data visualisation contracts, and export-ready performance reports.',
+    stack: ['Python', 'FastAPI', 'pandas', 'NumPy'],
+    links: [{ label: 'Explore code', href: 'https://github.com/BilliamsFluster/strategy-sandbox', variant: 'outline' }],
   },
 ];
 
@@ -62,45 +59,88 @@ const Portfolio = ({ onClose }) => {
         <div className="section-header__meta">
           <div>
             <p className="section-eyebrow">Portfolio</p>
-            <h2 className="section-title">Selected builds & experiments</h2>
+            <h2 className="section-title">Web works & product experiments</h2>
           </div>
           <Button variant="ghost" size="sm" onClick={onClose}>
             Back to scene
           </Button>
         </div>
         <p className="section-lead">
-          A mix of shipped work and personal explorations that helped me grow as a programmer, designer, and collaborator.
-          Each project strengthened my ability to prototype quickly while still keeping codebases approachable.
+          A collection of web-first builds that highlight how I design, integrate, and ship full-stack experiences. Each
+          project is structured to make future iterations simple to add—drop a new card into the data arrays and it will
+          slot neatly into the layout.
         </p>
       </div>
 
-      <div className="projects-grid">
-        {projects.map((project) => (
-          <article key={project.title} className="project-card">
-            <div className="project-card__header">
+      <section className="works-section">
+        <header className="section-subheader">
+          <h3 className="section-subtitle">Featured work</h3>
+          <p className="section-card__meta">Deep dives into end-to-end product deliveries.</p>
+        </header>
+        <div className="featured-works">
+          {featuredWorks.map((work) => (
+            <article key={work.title} className="project-card project-card--featured">
+              <div className="project-card__header">
+                <h3 className="project-card__title">{work.title}</h3>
+                <div className="project-card__tags">
+                  {work.stack.map((tag) => (
+                    <span key={tag} className="project-card__tag">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <p className="project-card__body">{work.summary}</p>
+              <ul className="project-card__list">
+                {work.highlights.map((highlight) => (
+                  <li key={highlight}>{highlight}</li>
+                ))}
+              </ul>
+              <div className="project-card__footer">
+                {work.links.map((link) => (
+                  <Button key={link.href} variant={link.variant} size="sm" asChild>
+                    <a href={link.href} target="_blank" rel="noreferrer">
+                      {link.label}
+                    </a>
+                  </Button>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="works-section">
+        <header className="section-subheader">
+          <h3 className="section-subtitle">Additional builds</h3>
+          <p className="section-card__meta">Compact snapshots that show range across the stack.</p>
+        </header>
+        <div className="projects-grid projects-grid--supporting">
+          {supportingProjects.map((project) => (
+            <article key={project.title} className="project-card">
               <h3 className="project-card__title">{project.title}</h3>
+              <p className="project-card__body">{project.description}</p>
+              <p className="section-card__meta">{project.impact}</p>
               <div className="project-card__tags">
-                {project.tags.map((tag) => (
+                {project.stack.map((tag) => (
                   <span key={tag} className="project-card__tag">
                     {tag}
                   </span>
                 ))}
               </div>
-            </div>
-            <p className="project-card__body">{project.summary}</p>
-            <p className="section-card__meta">{project.challenge}</p>
-            <div className="project-card__footer">
-              {project.links.map((link) => (
-                <Button key={link.href} variant={link.variant} size="sm" asChild>
-                  <a href={link.href} target="_blank" rel="noreferrer">
-                    {link.label}
-                  </a>
-                </Button>
-              ))}
-            </div>
-          </article>
-        ))}
-      </div>
+              <div className="project-card__footer">
+                {project.links.map((link) => (
+                  <Button key={link.href} variant={link.variant} size="sm" asChild>
+                    <a href={link.href} target="_blank" rel="noreferrer">
+                      {link.label}
+                    </a>
+                  </Button>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- rewrite the About section around web development strengths, recent impact, and updated skill groupings
- rebuild the Portfolio overlay with featured and supporting web projects so new work can be added via data arrays
- widen and center the sheet layout while updating grid styles to relieve cramped spacing when overlays open

## Testing
- npm run lint *(fails: existing lint configuration flags numerous legacy prop-type and react-three-fiber issues across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d057474b888331b2c9a254232f1e8d