### PR TITLE
Add Lenis scrolling and camera smoothing

### DIFF
--- a/r3f/src/App.css
+++ b/r3f/src/App.css
@@ -147,6 +147,10 @@ body {
   padding: clamp(1.5rem, 3vw, 2.25rem);
 }
 
+.shad-scroll-area[data-lenis-enabled='true'] .shad-scroll-area__viewport {
+  will-change: transform;
+}
+
 .shad-scroll-area__viewport::-webkit-scrollbar {
   width: 8px;
 }


### PR DESCRIPTION
## Summary
- add a Lenis-powered smooth scrolling hook that activates for the About, Portfolio, and Contact overlays with reduced-motion fallback
- mark the scroll container so Lenis can manage transforms while keeping the original scrollbar styles when inactive
- replace the GSAP camera jumps with damped OrbitControls smoothing so focus transitions ease into place and user input feels softer

## Testing
- npm run lint *(fails: existing lint/prop-type violations throughout project)*

------
https://chatgpt.com/codex/tasks/task_e_68d062cb5d6c8331ab8df344533cd635