### PR TITLE
Revamp portfolio showcase layout with linkable cards

### DIFF
--- a/r3f/public/static/portfolio/immersive-portfolio-preview.svg
+++ b/r3f/public/static/portfolio/immersive-portfolio-preview.svg
@@ -1,0 +1,27 @@
+<svg width="800" height="500" viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#312e81" />
+      <stop offset="100%" stop-color="#1e1b4b" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#f472b6" stop-opacity="0.75" />
+      <stop offset="100%" stop-color="#22d3ee" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="800" height="500" rx="32" fill="url(#bg)" />
+  <circle cx="400" cy="180" r="220" fill="url(#glow)" />
+  <rect x="120" y="120" width="560" height="300" rx="28" fill="rgba(17, 24, 39, 0.82)" stroke="rgba(244, 114, 182, 0.55)" stroke-width="2" />
+  <g transform="translate(180,190)" font-family="'Space Grotesk', sans-serif" fill="#fdf4ff">
+    <text x="0" y="0" font-size="32" font-weight="600">Immersive Portfolio World</text>
+    <text x="0" y="38" font-size="20" fill="rgba(224, 231, 255, 0.85)">3D storytelling layered with motion design.</text>
+  </g>
+  <g transform="translate(180,260)" font-family="'Space Grotesk', sans-serif" font-size="18" fill="#bae6fd">
+    <text x="0" y="0">• React Three Fiber hero scene</text>
+    <text x="0" y="32">• Cinematic lighting & shaders</text>
+    <text x="0" y="64">• Scroll-triggered GSAP beats</text>
+  </g>
+  <text x="120" y="460" font-family="'Space Grotesk', sans-serif" font-size="18" fill="rgba(196, 181, 253, 0.75)">
+    Swap this placeholder by saving a screenshot to /public/static/portfolio/immersive-portfolio-preview.svg
+  </text>
+</svg>

--- a/r3f/public/static/portfolio/primepastures-preview.svg
+++ b/r3f/public/static/portfolio/primepastures-preview.svg
@@ -1,0 +1,32 @@
+<svg width="800" height="500" viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#113a2c" />
+      <stop offset="100%" stop-color="#2b6e38" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#facc15" />
+      <stop offset="100%" stop-color="#f97316" />
+    </linearGradient>
+    <clipPath id="window">
+      <rect x="60" y="80" width="680" height="340" rx="26" />
+    </clipPath>
+  </defs>
+  <rect width="800" height="500" fill="url(#bg)" rx="32" />
+  <rect x="30" y="40" width="740" height="420" rx="30" fill="rgba(15,23,42,0.8)" stroke="rgba(226,232,240,0.2)" stroke-width="2" />
+  <g clip-path="url(#window)">
+    <rect x="60" y="80" width="680" height="220" fill="#0f172a" />
+    <rect x="60" y="300" width="680" height="120" fill="#f1f5f9" opacity="0.1" />
+    <path d="M60 260 Q 160 220 260 240 T 460 230 T 740 250 L 740 300 L 60 300 Z" fill="url(#accent)" opacity="0.85" />
+    <g fill="#f8fafc" font-family="'Space Grotesk', sans-serif" font-weight="600">
+      <text x="100" y="160" font-size="36">Prime Pastures Meat</text>
+      <text x="100" y="205" font-size="20" opacity="0.75">Farm-to-table storefront & subscription boxes</text>
+    </g>
+    <g fill="#bbf7d0" font-family="'EB Garamond', serif" font-size="26" font-weight="500">
+      <text x="100" y="360">Locally raised, responsibly sourced.</text>
+    </g>
+  </g>
+  <g fill="#bbf7d0" opacity="0.85" font-family="'Space Grotesk', sans-serif" font-size="18">
+    <text x="60" y="460">Drop in your own screenshot at /public/static/portfolio/primepastures-preview.svg</text>
+  </g>
+</svg>

--- a/r3f/public/static/portfolio/stockbot-preview.svg
+++ b/r3f/public/static/portfolio/stockbot-preview.svg
@@ -1,0 +1,33 @@
+<svg width="800" height="500" viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="grid" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#22d3ee" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#6366f1" stop-opacity="0.2" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" rx="32" fill="url(#bg)" />
+  <g stroke="rgba(148, 163, 184, 0.2)" stroke-width="1">
+    <path d="M80 120 H720" />
+    <path d="M80 200 H720" />
+    <path d="M80 280 H720" />
+    <path d="M80 360 H720" />
+  </g>
+  <polyline points="80,330 160,280 220,310 300,240 360,270 420,180 500,210 560,160 640,190 720,140" fill="none" stroke="url(#grid)" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" />
+  <rect x="120" y="80" width="560" height="340" rx="28" fill="rgba(15,23,42,0.85)" stroke="rgba(99,102,241,0.45)" stroke-width="2" />
+  <g transform="translate(160,140)">
+    <text x="0" y="0" font-family="'Space Grotesk', sans-serif" font-size="34" font-weight="600" fill="#e0f2fe">Stock Bot Command Center</text>
+    <text x="0" y="40" font-family="'Space Grotesk', sans-serif" font-size="20" fill="rgba(148, 163, 184, 0.85)">Voice-driven trading tools & live analytics.</text>
+  </g>
+  <g transform="translate(160,230)" font-family="'Space Grotesk', sans-serif" font-size="18" fill="#a5b4fc">
+    <text x="0" y="0">• Real-time equities feed</text>
+    <text x="0" y="32">• LLM trade assistant</text>
+    <text x="0" y="64">• Multi-broker orchestration</text>
+  </g>
+  <text x="120" y="460" font-family="'Space Grotesk', sans-serif" font-size="18" fill="rgba(165, 180, 252, 0.7)">
+    Replace this placeholder by exporting a 1600×1000 screenshot to /public/static/portfolio/stockbot-preview.svg
+  </text>
+</svg>

--- a/r3f/src/App.css
+++ b/r3f/src/App.css
@@ -388,6 +388,45 @@ body {
   filter: drop-shadow(0 18px 35px rgba(59, 130, 246, 0.25));
 }
 
+.project-stack-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.project-stack-list__item {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.9rem;
+  padding: 1rem 1.1rem;
+  background: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.project-stack-list__heading h4 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+}
+
+.project-stack-list__heading p {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.project-stack-list__item ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.project-stack-list__item li::marker {
+  color: rgba(59, 130, 246, 0.8);
+}
+
 .projects-grid {
   display: grid;
   gap: 1.2rem;
@@ -396,6 +435,10 @@ body {
 
 .projects-grid--supporting {
   gap: 1.35rem;
+}
+
+.projects-grid--feature {
+  gap: 1.5rem;
 }
 
 .works-section {
@@ -426,6 +469,37 @@ body {
   border-color: rgba(59, 130, 246, 0.4);
   background: linear-gradient(170deg, rgba(30, 64, 175, 0.32), rgba(15, 23, 42, 0.78));
   box-shadow: 0 28px 55px rgba(30, 64, 175, 0.35);
+}
+
+.project-card--spotlight {
+  display: grid;
+  grid-template-columns: minmax(0, 230px) minmax(0, 1fr);
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-color: rgba(59, 130, 246, 0.4);
+  background: linear-gradient(170deg, rgba(30, 64, 175, 0.28), rgba(15, 23, 42, 0.82));
+}
+
+.project-card__media {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  min-height: 160px;
+}
+
+.project-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.project-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .project-card__header {
@@ -476,6 +550,25 @@ body {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.portfolio-plan {
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.18), rgba(15, 23, 42, 0.7));
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  border-radius: 1rem;
+  padding: 1.35rem 1.5rem;
+  display: grid;
+  gap: 0.8rem;
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.38);
+}
+
+.portfolio-plan__list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
 }
 
 .contact-panel {
@@ -557,5 +650,13 @@ body {
 
   .shad-scroll-area__viewport {
     padding: 1.5rem;
+  }
+
+  .project-card--spotlight {
+    grid-template-columns: 1fr;
+  }
+
+  .project-card__media {
+    min-height: 180px;
   }
 }

--- a/r3f/src/components/about.jsx
+++ b/r3f/src/components/about.jsx
@@ -30,6 +30,24 @@ const impactHighlights = [
   'Engineered a configurable backtesting and momentum strategy framework with ATR stops, slippage modelling, and performance metrics.',
 ];
 
+const projectStacks = [
+  {
+    name: 'Prime Pastures Meat',
+    focus: 'Farm-to-table subscriptions and seasonal product drops.',
+    stack: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Sanity CMS', 'Stripe Checkout'],
+  },
+  {
+    name: 'Stock Bot Web Application',
+    focus: 'Voice-assisted trading cockpit with real-time analytics.',
+    stack: ['Next.js', 'Express', 'FastAPI', 'MongoDB', 'LLMs'],
+  },
+  {
+    name: 'Immersive Portfolio World',
+    focus: 'React Three Fiber scene paired with GSAP storytelling.',
+    stack: ['React', 'React Three Fiber', 'Three.js', 'GSAP', 'Vite'],
+  },
+];
+
 const About = ({ onClose }) => {
   return (
     <div className="section-wrapper">
@@ -94,6 +112,26 @@ const About = ({ onClose }) => {
                   <li key={item}>{item}</li>
                 ))}
               </ul>
+            ))}
+          </div>
+        </div>
+
+        <div className="section-card">
+          <h3 className="section-card__title">Frameworks per showcase</h3>
+          <p className="section-card__meta">Where each live site in the portfolio draws its power.</p>
+          <div className="project-stack-list">
+            {projectStacks.map((project) => (
+              <div key={project.name} className="project-stack-list__item">
+                <div className="project-stack-list__heading">
+                  <h4>{project.name}</h4>
+                  <p>{project.focus}</p>
+                </div>
+                <ul>
+                  {project.stack.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
             ))}
           </div>
         </div>

--- a/r3f/src/components/portfolio.jsx
+++ b/r3f/src/components/portfolio.jsx
@@ -1,54 +1,58 @@
 import React from 'react';
 import Button from './ui/button';
 
-const featuredWorks = [
+const planOfAttack = [
+  'Drop a fresh screenshot into /public/static/portfolio and update the filename in the portfolioWorks array.',
+  'Add a new object to the portfolioWorks array with the title, live URL, summary, and highlight bullets.',
+  'Optionally pair it with a secondary link (case study, repo, or brief) so prospects can dive deeper.',
+];
+
+const portfolioWorks = [
+  {
+    title: 'Prime Pastures Meat',
+    role: 'Farm-to-table eCommerce storefront',
+    summary:
+      'Direct-to-consumer experience for a regenerative farm co-op featuring subscription boxes, seasonal drops, and story-driven merchandising.',
+    highlights: [
+      'Crafted conversion-focused landing flows that surface sourcing standards, fulfilment windows, and bundle savings.',
+      'Synced product data, add-to-cart states, and waitlists so the team can manage inventory surges without developer intervention.',
+      'Wove brand photography with earthy gradients for a premium but grounded feel that mirrors the in-person farm tour.',
+    ],
+    image: '/static/portfolio/primepastures-preview.svg',
+    links: [{ label: 'Visit website', href: 'https://primepasturesmeat.com/', variant: 'default' }],
+  },
   {
     title: 'Stock Bot Web Application',
+    role: 'AI-assisted trading platform',
     summary:
-      'AI-assisted trading platform that combines a Next.js front-end, Node/Express orchestration layer, and a Python trading engine.',
+      'Unified trading cockpit where equities data, broker operations, and a Jarvis-style voice assistant sit behind one responsive interface.',
     highlights: [
-      'Unified real-time market data, automated strategies, and broker operations into a single portfolio dashboard.',
-      'Delivered Schwab OAuth onboarding with AES-256-GCM token storage and brokerage account verification using Mongoose hooks.',
-      'Built a Jarvis voice assistant loop that streams SpeechRecognition into LLM prompts and TTS playback for hands-free trade execution.',
-      'Shipped a backtesting toolkit with momentum strategies, ATR-based risk controls, and slippage modelling for accurate performance insights.',
+      'Streams real-time quotes, automated strategies, and alerts into a single watchlist that syncs across desktop and mobile sessions.',
+      'Secures brokerage access with Schwab OAuth, encrypted token vaulting, and verification routines that reduce onboarding friction.',
+      'Pairs LLM prompts with speech recognition and text-to-speech so traders can run backtests or place trades without touching the keyboard.',
     ],
-    stack: ['Next.js', 'Express', 'FastAPI', 'MongoDB', 'WebSockets', 'LLMs', 'GSAP'],
+    image: '/static/portfolio/stockbot-preview.svg',
     links: [
+      { label: 'Visit website', href: 'https://stock-bot.dev/', variant: 'default' },
       {
-        label: 'View architecture notes',
+        label: 'Read architecture notes',
         href: 'https://docs.google.com/document/d/12GtkKixHYPvFlJCWfXx_4etS_pKIu5v70eESW6R86J4',
-        variant: 'default',
+        variant: 'outline',
       },
     ],
   },
-];
-
-const supportingProjects = [
   {
-    title: 'Immersive Portfolio',
-    description:
-      'Interactive personal site where visitors explore projects inside a playable React Three Fiber world layered with GSAP storytelling.',
-    impact:
-      'Reinforced my ability to blend creative direction, shader-driven visuals, and accessible UI states within a single codebase.',
-    stack: ['React', 'React Three Fiber', 'GSAP'],
-    links: [{ label: 'Visit site', href: 'https://bwap.netlify.app/', variant: 'default' }],
-  },
-  {
-    title: 'Film Explorer',
-    description:
-      'Responsive web app that surfaces curated watchlists by orchestrating third-party film APIs with debounced search and filter states.',
-    impact: 'Showcased pragmatic data modelling, resilient error states, and reusable UI primitives for content-heavy experiences.',
-    stack: ['React', 'REST APIs', 'CSS Modules'],
-    links: [{ label: 'View GitHub', href: 'https://github.com/BilliamsFluster/react_film_site', variant: 'outline' }],
-  },
-  {
-    title: 'Strategy Sandbox',
-    description:
-      'Configurable analysis suite that lets traders prototype momentum ideas, tweak ATR-based stops, and visualise returns before deploying.',
-    impact:
-      'Extended my backtesting engine with reusable hooks, clear data visualisation contracts, and export-ready performance reports.',
-    stack: ['Python', 'FastAPI', 'pandas', 'NumPy'],
-    links: [{ label: 'Explore code', href: 'https://github.com/BilliamsFluster/strategy-sandbox', variant: 'outline' }],
+    title: 'Immersive Portfolio World',
+    role: 'Interactive 3D showcase',
+    summary:
+      'Playable React Three Fiber experience that introduces my services through cinematic lighting, guided camera paths, and responsive UI overlays.',
+    highlights: [
+      'Balances performant shaders, bloom, and post-processing with accessibility-minded controls and focus states.',
+      'Coordinates GSAP timelines with scroll cues so each section reveals context and calls-to-action at the right pace.',
+      'Bundles all data-driven sections—About, Portfolio, Contact—into JSON-friendly arrays for rapid content refreshes.',
+    ],
+    image: '/static/portfolio/immersive-portfolio-preview.svg',
+    links: [{ label: 'Visit website', href: 'https://bwap.netlify.app/', variant: 'default' }],
   },
 ];
 
@@ -66,76 +70,54 @@ const Portfolio = ({ onClose }) => {
           </Button>
         </div>
         <p className="section-lead">
-          A collection of web-first builds that highlight how I design, integrate, and ship full-stack experiences. Each
-          project is structured to make future iterations simple to add—drop a new card into the data arrays and it will
-          slot neatly into the layout.
+          A collection of web-first builds that highlight how I design, integrate, and ship full-stack experiences. The plan
+          below shows exactly how to plug in new client work: provide the URL, a short description, three punchy highlights,
+          and a screenshot.
         </p>
       </div>
 
-      <section className="works-section">
-        <header className="section-subheader">
-          <h3 className="section-subtitle">Featured work</h3>
-          <p className="section-card__meta">Deep dives into end-to-end product deliveries.</p>
-        </header>
-        <div className="featured-works">
-          {featuredWorks.map((work) => (
-            <article key={work.title} className="project-card project-card--featured">
-              <div className="project-card__header">
-                <h3 className="project-card__title">{work.title}</h3>
-                <div className="project-card__tags">
-                  {work.stack.map((tag) => (
-                    <span key={tag} className="project-card__tag">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              </div>
-              <p className="project-card__body">{work.summary}</p>
-              <ul className="project-card__list">
-                {work.highlights.map((highlight) => (
-                  <li key={highlight}>{highlight}</li>
-                ))}
-              </ul>
-              <div className="project-card__footer">
-                {work.links.map((link) => (
-                  <Button key={link.href} variant={link.variant} size="sm" asChild>
-                    <a href={link.href} target="_blank" rel="noreferrer">
-                      {link.label}
-                    </a>
-                  </Button>
-                ))}
-              </div>
-            </article>
+      <section className="portfolio-plan">
+        <h3 className="section-subtitle">Plan of attack for new showcases</h3>
+        <ol className="portfolio-plan__list">
+          {planOfAttack.map((step) => (
+            <li key={step}>{step}</li>
           ))}
-        </div>
+        </ol>
       </section>
 
       <section className="works-section">
         <header className="section-subheader">
-          <h3 className="section-subtitle">Additional builds</h3>
-          <p className="section-card__meta">Compact snapshots that show range across the stack.</p>
+          <h3 className="section-subtitle">Live web builds</h3>
+          <p className="section-card__meta">Each card pairs a live link with context and visuals for clients.</p>
         </header>
-        <div className="projects-grid projects-grid--supporting">
-          {supportingProjects.map((project) => (
-            <article key={project.title} className="project-card">
-              <h3 className="project-card__title">{project.title}</h3>
-              <p className="project-card__body">{project.description}</p>
-              <p className="section-card__meta">{project.impact}</p>
-              <div className="project-card__tags">
-                {project.stack.map((tag) => (
-                  <span key={tag} className="project-card__tag">
-                    {tag}
-                  </span>
-                ))}
+        <div className="projects-grid projects-grid--feature">
+          {portfolioWorks.map((work) => (
+            <article key={work.title} className="project-card project-card--spotlight">
+              <div className="project-card__media">
+                <img src={work.image} alt={`${work.title} website preview`} />
               </div>
-              <div className="project-card__footer">
-                {project.links.map((link) => (
-                  <Button key={link.href} variant={link.variant} size="sm" asChild>
-                    <a href={link.href} target="_blank" rel="noreferrer">
-                      {link.label}
-                    </a>
-                  </Button>
-                ))}
+              <div className="project-card__content">
+                <div className="project-card__header">
+                  <div>
+                    <h3 className="project-card__title">{work.title}</h3>
+                    <p className="section-card__meta">{work.role}</p>
+                  </div>
+                </div>
+                <p className="project-card__body">{work.summary}</p>
+                <ul className="project-card__list">
+                  {work.highlights.map((highlight) => (
+                    <li key={highlight}>{highlight}</li>
+                  ))}
+                </ul>
+                <div className="project-card__footer">
+                  {work.links.map((link) => (
+                    <Button key={link.href} variant={link.variant} size="sm" asChild>
+                      <a href={link.href} target="_blank" rel="noreferrer">
+                        {link.label}
+                      </a>
+                    </Button>
+                  ))}
+                </div>
               </div>
             </article>
           ))}


### PR DESCRIPTION
## Summary
- replace the portfolio section with live website cards, plan-of-attack guidance, and imagery placeholders for each showcase
- move per-project framework details into the About section alongside existing skills
- add supporting styles and SVG preview assets for the updated portfolio presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6ea979534833184dcc2a19f7c3ce5