### PR TITLE
Refine about and portfolio layouts

### DIFF
--- a/r3f/src/App.css
+++ b/r3f/src/App.css
@@ -273,11 +273,6 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.section-grid--about {
-  grid-auto-rows: 1fr;
-  align-items: stretch;
-}
-
 .section-card {
   background: linear-gradient(145deg, rgba(15, 23, 42, 0.8), rgba(30, 41, 59, 0.55));
   border: 1px solid rgba(148, 163, 184, 0.18);
@@ -335,6 +330,55 @@ body {
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+.about-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    'portrait'
+    'build'
+    'impact'
+    'skill'
+    'frameworks';
+}
+
+.about-grid__portrait {
+  grid-area: portrait;
+}
+
+.about-grid__build {
+  grid-area: build;
+}
+
+.about-grid__impact {
+  grid-area: impact;
+}
+
+.about-grid__skill {
+  grid-area: skill;
+}
+
+.about-grid__frameworks {
+  grid-area: frameworks;
+}
+
+@media (min-width: 768px) {
+  .about-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .about-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      'build portrait'
+      'skill impact'
+      'frameworks frameworks';
+    align-items: start;
+  }
 }
 
 .skill-columns {
@@ -429,8 +473,8 @@ body {
 
 .projects-grid {
   display: grid;
-  gap: 1.2rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
 }
 
 .projects-grid--supporting {
@@ -472,8 +516,8 @@ body {
 }
 
 .project-card--spotlight {
-  display: grid;
-  grid-template-columns: minmax(0, 230px) minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   gap: 1.25rem;
   padding: 1.5rem;
   border-color: rgba(59, 130, 246, 0.4);
@@ -486,12 +530,11 @@ body {
   border-radius: 0.85rem;
   border: 1px solid rgba(148, 163, 184, 0.25);
   background: rgba(15, 23, 42, 0.75);
-  min-height: 160px;
 }
 
 .project-card__media img {
   width: 100%;
-  height: 100%;
+  height: auto;
   object-fit: cover;
   display: block;
 }
@@ -550,25 +593,6 @@ body {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
-}
-
-.portfolio-plan {
-  background: linear-gradient(160deg, rgba(37, 99, 235, 0.18), rgba(15, 23, 42, 0.7));
-  border: 1px solid rgba(59, 130, 246, 0.35);
-  border-radius: 1rem;
-  padding: 1.35rem 1.5rem;
-  display: grid;
-  gap: 0.8rem;
-  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.38);
-}
-
-.portfolio-plan__list {
-  margin: 0;
-  padding-left: 1.25rem;
-  display: grid;
-  gap: 0.6rem;
-  font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.85);
 }
 
 .contact-panel {

--- a/r3f/src/components/about.jsx
+++ b/r3f/src/components/about.jsx
@@ -67,8 +67,12 @@ const About = ({ onClose }) => {
         </p>
       </div>
 
-      <div className="section-grid section-grid--about">
-        <div className="section-card section-card--primary">
+      <div className="about-grid">
+        <div className="section-card about-portrait about-grid__portrait">
+          <img src="/static/Billy.png" alt="Portrait of William Wapniarek" />
+        </div>
+
+        <div className="section-card section-card--primary about-grid__build">
           <h3 className="section-card__title">How I build</h3>
           <p className="project-card__body">
             I translate complex financial workflows into approachable web applications. My focus is pairing reliable
@@ -89,7 +93,7 @@ const About = ({ onClose }) => {
           </Button>
         </div>
 
-        <div className="section-card">
+        <div className="section-card about-grid__impact">
           <h3 className="section-card__title">Recent impact</h3>
           <p className="section-card__meta">Stock Bot Web Application</p>
           <ul className="section-list">
@@ -99,7 +103,7 @@ const About = ({ onClose }) => {
           </ul>
         </div>
 
-        <div className="section-card">
+        <div className="section-card about-grid__skill">
           <h3 className="section-card__title">Skill snapshot</h3>
           <p className="section-card__meta">Tooling I reach for when shaping web platforms.</p>
           <div className="skill-columns">
@@ -116,7 +120,7 @@ const About = ({ onClose }) => {
           </div>
         </div>
 
-        <div className="section-card">
+        <div className="section-card about-grid__frameworks">
           <h3 className="section-card__title">Frameworks per showcase</h3>
           <p className="section-card__meta">Where each live site in the portfolio draws its power.</p>
           <div className="project-stack-list">
@@ -134,10 +138,6 @@ const About = ({ onClose }) => {
               </div>
             ))}
           </div>
-        </div>
-
-        <div className="section-card about-portrait">
-          <img src="/static/Billy.png" alt="Portrait of William Wapniarek" />
         </div>
       </div>
     </div>

--- a/r3f/src/components/portfolio.jsx
+++ b/r3f/src/components/portfolio.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 import Button from './ui/button';
 
-const planOfAttack = [
-  'Drop a fresh screenshot into /public/static/portfolio and update the filename in the portfolioWorks array.',
-  'Add a new object to the portfolioWorks array with the title, live URL, summary, and highlight bullets.',
-  'Optionally pair it with a secondary link (case study, repo, or brief) so prospects can dive deeper.',
-];
-
 const portfolioWorks = [
   {
     title: 'Prime Pastures Meat',
@@ -70,20 +64,10 @@ const Portfolio = ({ onClose }) => {
           </Button>
         </div>
         <p className="section-lead">
-          A collection of web-first builds that highlight how I design, integrate, and ship full-stack experiences. The plan
-          below shows exactly how to plug in new client work: provide the URL, a short description, three punchy highlights,
-          and a screenshot.
+          A collection of web-first builds that highlight how I design, integrate, and ship full-stack experiences. Each
+          showcase pairs visuals with the exact impact delivered so new prospects can explore how I solve their challenges.
         </p>
       </div>
-
-      <section className="portfolio-plan">
-        <h3 className="section-subtitle">Plan of attack for new showcases</h3>
-        <ol className="portfolio-plan__list">
-          {planOfAttack.map((step) => (
-            <li key={step}>{step}</li>
-          ))}
-        </ol>
-      </section>
 
       <section className="works-section">
         <header className="section-subheader">


### PR DESCRIPTION
## Summary
- restructure the about section with a responsive grid that pairs the portrait with the "How I build" card and keeps impact and skills flowing underneath
- simplify the portfolio showcase by removing the plan-of-attack block and stacking spotlight cards with media on top across all breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6f00caefc83319d2a1c8d14bcf9ef